### PR TITLE
Solidity compiler custom arguments

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -85,7 +85,7 @@ func main() {
 		var contracts map[string]*compiler.Contract
 		var err error
 		if *solFlag != "" {
-			contracts, err = compiler.CompileSolidity(*solcFlag, *solFlag)
+			contracts, err = compiler.CompileSolidity(*solcFlag, "", *solFlag)
 			if err != nil {
 				fmt.Printf("Failed to build Solidity contract: %v\n", err)
 				os.Exit(-1)

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -109,7 +109,7 @@ func SolidityVersion(solc string) (*Solidity, error) {
 }
 
 // CompileSolidityString builds and returns all the contracts contained within a source string.
-func CompileSolidityString(solc, source string) (map[string]*Contract, error) {
+func CompileSolidityString(solc, customArgs, source string) (map[string]*Contract, error) {
 	if len(source) == 0 {
 		return nil, errors.New("solc: empty source string")
 	}
@@ -118,7 +118,7 @@ func CompileSolidityString(solc, source string) (map[string]*Contract, error) {
 		return nil, err
 	}
 	args := append(s.makeArgs(), "--")
-	cmd := exec.Command(s.Path, append(args, "-")...)
+	cmd := exec.Command(s.Path, append(append(args, customArgs), "-")...)
 	cmd.Stdin = strings.NewReader(source)
 	return s.run(cmd, source)
 }
@@ -137,9 +137,6 @@ func CompileSolidity(solc string, customArgs string, sourcefiles ...string) (map
 		return nil, err
 	}
 	args := append(s.makeArgs(), "--")
-	fmt.Println(args)
-	fmt.Println(append(args, customArgs))
-	fmt.Println(append(append(args, customArgs), sourcefiles...))
 	cmd := exec.Command(s.Path, append(append(args, customArgs), sourcefiles...)...)
 	return s.run(cmd, source)
 }

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -139,7 +139,7 @@ func CompileSolidity(solc string, customArgs string, sourcefiles ...string) (map
 	args := append(s.makeArgs(), "--")
 	fmt.Println(args)
 	fmt.Println(append(args, customArgs))
-	fmt.Println(append(append(args, customArgs), sourcefiles...)...)
+	fmt.Println(append(append(args, customArgs), sourcefiles...))
 	cmd := exec.Command(s.Path, append(append(args, customArgs), sourcefiles...)...)
 	return s.run(cmd, source)
 }

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -137,6 +137,9 @@ func CompileSolidity(solc string, customArgs string, sourcefiles ...string) (map
 		return nil, err
 	}
 	args := append(s.makeArgs(), "--")
+	fmt.Println(args)
+	fmt.Println(append(args, customArgs))
+	fmt.Println(append(append(args, customArgs), sourcefiles...)...)
 	cmd := exec.Command(s.Path, append(append(args, customArgs), sourcefiles...)...)
 	return s.run(cmd, source)
 }

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -117,8 +117,8 @@ func CompileSolidityString(solc, customArgs, source string) (map[string]*Contrac
 	if err != nil {
 		return nil, err
 	}
-	args := append(s.makeArgs(), "--")
-	cmd := exec.Command(s.Path, append(append(args, customArgs), "-")...)
+	args := append(s.makeArgs(), customArgs)
+	cmd := exec.Command(s.Path, append(args, "-")...)
 	cmd.Stdin = strings.NewReader(source)
 	return s.run(cmd, source)
 }
@@ -136,8 +136,8 @@ func CompileSolidity(solc string, customArgs string, sourcefiles ...string) (map
 	if err != nil {
 		return nil, err
 	}
-	args := append(s.makeArgs(), "--")
-	cmd := exec.Command(s.Path, append(append(args, customArgs), sourcefiles...)...)
+	args := append(s.makeArgs(), customArgs)
+	cmd := exec.Command(s.Path, append(args, sourcefiles...)...)
 	return s.run(cmd, source)
 }
 

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -109,7 +109,7 @@ func SolidityVersion(solc string) (*Solidity, error) {
 }
 
 // CompileSolidityString builds and returns all the contracts contained within a source string.
-func CompileSolidityString(solc, customArgs, source string) (map[string]*Contract, error) {
+func CompileSolidityString(solc string, customArgs []string, source string) (map[string]*Contract, error) {
 	if len(source) == 0 {
 		return nil, errors.New("solc: empty source string")
 	}

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -117,14 +117,14 @@ func CompileSolidityString(solc, customArgs, source string) (map[string]*Contrac
 	if err != nil {
 		return nil, err
 	}
-	args := append(s.makeArgs(), customArgs)
+	args := append(s.makeArgs(), customArgs...)
 	cmd := exec.Command(s.Path, append(args, "-")...)
 	cmd.Stdin = strings.NewReader(source)
 	return s.run(cmd, source)
 }
 
 // CompileSolidity compiles all given Solidity source files.
-func CompileSolidity(solc string, customArgs string, sourcefiles ...string) (map[string]*Contract, error) {
+func CompileSolidity(solc string, customArgs []string, sourcefiles ...string) (map[string]*Contract, error) {
 	if len(sourcefiles) == 0 {
 		return nil, errors.New("solc: no source files")
 	}
@@ -136,7 +136,7 @@ func CompileSolidity(solc string, customArgs string, sourcefiles ...string) (map
 	if err != nil {
 		return nil, err
 	}
-	args := append(s.makeArgs(), customArgs)
+	args := append(s.makeArgs(), customArgs...)
 	cmd := exec.Command(s.Path, append(args, sourcefiles...)...)
 	return s.run(cmd, source)
 }

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -124,7 +124,7 @@ func CompileSolidityString(solc, source string) (map[string]*Contract, error) {
 }
 
 // CompileSolidity compiles all given Solidity source files.
-func CompileSolidity(solc string, sourcefiles ...string) (map[string]*Contract, error) {
+func CompileSolidity(solc string, customArgs string, sourcefiles ...string) (map[string]*Contract, error) {
 	if len(sourcefiles) == 0 {
 		return nil, errors.New("solc: no source files")
 	}
@@ -137,7 +137,7 @@ func CompileSolidity(solc string, sourcefiles ...string) (map[string]*Contract, 
 		return nil, err
 	}
 	args := append(s.makeArgs(), "--")
-	cmd := exec.Command(s.Path, append(args, sourcefiles...)...)
+	cmd := exec.Command(s.Path, append(append(args, customArgs), sourcefiles...)...)
 	return s.run(cmd, source)
 }
 

--- a/common/compiler/solidity_test.go
+++ b/common/compiler/solidity_test.go
@@ -41,7 +41,7 @@ func skipWithoutSolc(t *testing.T) {
 func TestCompiler(t *testing.T) {
 	skipWithoutSolc(t)
 
-	contracts, err := CompileSolidityString("", testSource)
+	contracts, err := CompileSolidityString("", "", testSource)
 	if err != nil {
 		t.Fatalf("error compiling source. result %v: %v", contracts, err)
 	}
@@ -69,7 +69,7 @@ func TestCompiler(t *testing.T) {
 func TestCompileError(t *testing.T) {
 	skipWithoutSolc(t)
 
-	contracts, err := CompileSolidityString("", testSource[4:])
+	contracts, err := CompileSolidityString("", "", testSource[4:])
 	if err == nil {
 		t.Errorf("error expected compiling source. got none. result %v", contracts)
 	}


### PR DESCRIPTION
Current solidity compilation invokes solc. Solc can take more arguments that aren't able to be passed in for compilation and these have been added.

Motivation:
Compilation of contracts are restricted to the scope of the directory and all subdirectories of the target contract file by solc. Passing `--allow-paths` option and/or remapping arguments for relative paths allows solc to access other directories. Thus we need a way to pass custom arguments to the solc compiler. This is primarily used by the Ion CLI for contract compilation for deployment/execution. This does not seem to affect the client implementation.