### PR TITLE
Remove old enode check

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -33,7 +33,6 @@ import (
 	"github.com/clearmatics/autonity/core/types"
 	"github.com/clearmatics/autonity/ethdb"
 	"github.com/clearmatics/autonity/log"
-	"github.com/clearmatics/autonity/p2p/enode"
 	"github.com/clearmatics/autonity/params"
 	"github.com/clearmatics/autonity/rlp"
 )
@@ -297,24 +296,7 @@ func (g *Genesis) Commit(db ethdb.Database) (*types.Block, error) {
 	rawdb.WriteHeadBlockHash(db, block.Hash())
 	rawdb.WriteHeadHeaderHash(db, block.Hash())
 
-	enodeWhiteList := make([]*enode.Node, 0, len(config.EnodeWhitelist))
-	for _, enodeString := range config.EnodeWhitelist {
-		log.Info("Genesis Authorized Enode", "enode", enodeString)
-		newEnode, err := enode.ParseV4(enodeString)
-		if err != nil {
-			return nil, errGenesisBadWhitelist
-		}
-		enodeWhiteList = append(enodeWhiteList, newEnode)
-	}
-
-	if len(enodeWhiteList) != 0 {
-		var enodeWhiteListStr []string
-		for _, enodeID := range enodeWhiteList {
-			enodeWhiteListStr = append(enodeWhiteListStr, enodeID.String())
-		}
-		rawdb.WriteEnodeWhitelist(db, types.NewNodes(enodeWhiteListStr, false))
-	}
-
+	rawdb.WriteEnodeWhitelist(db, types.NewNodes(g.Config.EnodeWhitelist, false))
 	rawdb.WriteChainConfig(db, block.Hash(), g.Config)
 	return block, nil
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -273,9 +273,8 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 // Commit writes the block and state of a genesis specification to the database.
 // The block is committed as the canonical head block.
 func (g *Genesis) Commit(db ethdb.Database) (*types.Block, error) {
-	config := g.Config
-	if config == nil {
-		config = params.AllEthashProtocolChanges
+	if g.Config == nil {
+		g.Config = params.AllEthashProtocolChanges
 	}
 
 	if g.Config != nil && g.Config.Istanbul != nil {
@@ -296,7 +295,7 @@ func (g *Genesis) Commit(db ethdb.Database) (*types.Block, error) {
 	rawdb.WriteHeadBlockHash(db, block.Hash())
 	rawdb.WriteHeadHeaderHash(db, block.Hash())
 
-	rawdb.WriteEnodeWhitelist(db, types.NewNodes(g.Config.EnodeWhitelist, false))
+	rawdb.WriteEnodeWhitelist(db, types.NewNodes(g.Config.EnodeWhitelist, true))
 	rawdb.WriteChainConfig(db, block.Hash(), g.Config)
 	return block, nil
 }

--- a/core/types/nodes.go
+++ b/core/types/nodes.go
@@ -25,10 +25,9 @@ func NewNodes(strList []string, openNetwork bool) *Nodes {
 			if !openNetwork {
 				panic(err)
 			}
-		} else {
-			n.List = append(n.List, newEnode)
-			n.StrList = append(n.StrList, enodeStr)
 		}
+		n.List = append(n.List, newEnode)
+		n.StrList = append(n.StrList, enodeStr)
 	}
 
 	return n

--- a/core/types/nodes.go
+++ b/core/types/nodes.go
@@ -1,10 +1,12 @@
 package types
 
 import (
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/clearmatics/autonity/log"
 	"github.com/clearmatics/autonity/p2p/enode"
-	"sync"
-	"time"
 )
 
 type Nodes struct {
@@ -12,36 +14,89 @@ type Nodes struct {
 	StrList []string
 }
 
-func NewNodes(strList []string, openNetwork bool) *Nodes {
-	n := &Nodes{
-		[]*enode.Node{},
-		[]string{},
-	}
+const (
+	maxParseTries     = 300
+	delayBetweenTries = time.Second
+	defaultTTL        = 20
+)
 
-	getEnode := enode.ParseV4WithResolve
-	if !openNetwork {
-		getEnode = enode.GetParseV4WithResolveMaxTry(1000, time.Second)
+func NewNodes(strList []string, openNetwork bool) *Nodes {
+	getEnode := getParseFunc(openNetwork)
+
+	idx := new(int32)
+	wg := sync.WaitGroup{}
+	errCh := make(chan error, len(strList))
+
+	n := &Nodes{
+		make([]*enode.Node, len(strList)),
+		make([]string, len(strList)),
 	}
 
 	for _, enodeStr := range strList {
-		newEnode, err := cache.Get(enodeStr, getEnode)
-		if err != nil {
-			log.Error("Invalid whitelisted enode", "returned enode", enodeStr, "error", err.Error())
+		wg.Add(1)
 
-			if !openNetwork {
-				panic(err)
+		go func(enodeStr string) {
+			log.Error("performing", "node", enodeStr)
+			newEnode, err := cache.Get(enodeStr, getEnode)
+			if err != nil {
+				errCh <- err
 			}
-		}
-		n.List = append(n.List, newEnode)
-		n.StrList = append(n.StrList, enodeStr)
+
+			currentIdx := atomic.AddInt32(idx, 1) - 1
+			n.List[currentIdx] = newEnode
+			n.StrList[currentIdx] = enodeStr
+
+			wg.Done()
+		}(enodeStr)
 	}
 
-	return n
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+
+	if len(errs) != 0 {
+		if !openNetwork {
+			panic(errs)
+		}
+		log.Error("enodes parse errors", "errs", errs)
+	}
+
+	return filterNodes(n, openNetwork)
 }
 
-var cache = &domainCache{m:make(map[string]resolvedNode)}
+func filterNodes(n *Nodes, openNetwork bool) *Nodes {
+	filtered := &Nodes{
+		make([]*enode.Node, 0, len(n.List)),
+		make([]string, 0, len(n.StrList)),
+	}
 
-const defaultTTL = 20
+	for i, node := range n.List {
+		if node != nil {
+			filtered.List = append(filtered.List, node)
+		}
+
+		if openNetwork {
+			// we want to store raw enodes for later checks
+			filtered.StrList = append(filtered.StrList, n.StrList[i])
+		}
+	}
+
+	return filtered
+}
+
+func getParseFunc(openNetwork bool) func(string) (*enode.Node, error) {
+	getEnode := enode.ParseV4WithResolve
+	if !openNetwork {
+		getEnode = enode.GetParseV4WithResolveMaxTry(maxParseTries, delayBetweenTries)
+	}
+	return getEnode
+}
+
+var cache = &domainCache{m: make(map[string]resolvedNode)}
 
 type domainCache struct {
 	m map[string]resolvedNode
@@ -49,7 +104,7 @@ type domainCache struct {
 }
 
 type resolvedNode struct {
-	node *enode.Node
+	node  *enode.Node
 	count int
 }
 

--- a/core/types/nodes.go
+++ b/core/types/nodes.go
@@ -4,6 +4,7 @@ import (
 	"github.com/clearmatics/autonity/log"
 	"github.com/clearmatics/autonity/p2p/enode"
 	"sync"
+	"time"
 )
 
 type Nodes struct {
@@ -17,8 +18,13 @@ func NewNodes(strList []string, openNetwork bool) *Nodes {
 		[]string{},
 	}
 
+	getEnode := enode.ParseV4WithResolve
+	if !openNetwork {
+		getEnode = enode.GetParseV4WithResolveMaxTry(1000, time.Second)
+	}
+
 	for _, enodeStr := range strList {
-		newEnode, err := cache.Get(enodeStr, enode.ParseV4WithResolve)
+		newEnode, err := cache.Get(enodeStr, getEnode)
 		if err != nil {
 			log.Error("Invalid whitelisted enode", "returned enode", enodeStr, "error", err.Error())
 

--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/clearmatics/autonity/log"
 	"net"
 	"net/url"
 	"regexp"
@@ -101,6 +102,7 @@ func ParseV4WithResolveMaxTry(rawurl string, maxTry int, wait time.Duration) (*N
 			break
 		}
 		time.Sleep(wait)
+		log.Error("trying to parse", "enode", rawurl, "attempt", i)
 	}
 
 	return node, err

--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/clearmatics/autonity/common/math"
 	"github.com/clearmatics/autonity/crypto"
@@ -33,6 +34,7 @@ import (
 )
 
 var incompleteNodeURL = regexp.MustCompile("(?i)^(?:enode://)?([0-9a-f]+)$")
+
 const defaultPort = ":30303"
 
 // MustParseV4 parses a node URL. It panics if the URL is not valid.
@@ -82,6 +84,26 @@ func parseV4(rawurl string, resolve bool) (*Node, error) {
 	}
 
 	return parseComplete(rawurl, resolve)
+}
+
+func GetParseV4WithResolveMaxTry(maxTry int, wait time.Duration) func(rawurl string) (*Node, error) {
+	return func(rawurl string) (*Node, error) {
+		return ParseV4WithResolveMaxTry(rawurl, maxTry, wait)
+	}
+}
+
+func ParseV4WithResolveMaxTry(rawurl string, maxTry int, wait time.Duration) (*Node, error) {
+	var node *Node
+	var err error
+	for i := 0; i < maxTry; i++ {
+		node, err = ParseV4WithResolve(rawurl)
+		if err == nil {
+			break
+		}
+		time.Sleep(wait)
+	}
+
+	return node, err
 }
 
 func ParseV4WithResolve(rawurl string) (*Node, error) {
@@ -141,7 +163,7 @@ func parseComplete(rawurl string, resolve bool) (*Node, error) {
 
 	if ip = net.ParseIP(host); ip == nil {
 		if !resolve {
-			return nil, errors.New("invalid IP address", )
+			return nil, errors.New("invalid IP address")
 		}
 		// if host is not IPV4/6, resolve host is a domain
 


### PR DESCRIPTION
An old piece of code was restored after last master merge - https://github.com/clearmatics/autonity/pull/61/files#diff-3e8301305b1dc6d3f96fbe3429cda929L284

@eastata mentioned to me that we need to not to panic if some of enodes won't resolve on `autonity init` step. So I changed `types.Nodes` to not to panic when we parse nodes to write whiteList to the DB, but to panics on errors if we're reading from the DB. @yazzaoui Could you review the recent changes?

closes #74 