### PR TITLE
changed pendingUnminedBlocks type to map[uint64]*types.Block and fix data race in isProposer

### DIFF
--- a/consensus/tendermint/core/core.go
+++ b/consensus/tendermint/core/core.go
@@ -282,8 +282,7 @@ func (c *core) startRound(ctx context.Context, round *big.Int) {
 		if c.validValue != nil {
 			p = c.validValue
 		} else {
-			unmineBlock := c.getUnminedBlock()
-			p = unmineBlock
+			p = c.getUnminedBlock()
 			if p == nil {
 				select {
 				case <-ctx.Done():

--- a/consensus/tendermint/core/core.go
+++ b/consensus/tendermint/core/core.go
@@ -73,15 +73,15 @@ type Engine interface {
 // New creates an Istanbul consensus core
 func New(backend tendermint.Backend, config *tendermint.Config) Engine {
 	c := &core{
-		config:                      config,
-		address:                     backend.Address(),
-		logger:                      log.New(),
-		backend:                     backend,
-		backlogs:                    make(map[tendermint.Validator]*prque.Prque),
-		pendingUnminedBlocks:        prque.New(),
-		latestPendingUnminedBlockCh: make(chan *types.Block),
-		valSet:                      new(validatorSet),
-		futureRoundsChange:          make(map[int64]int64),
+		config:                config,
+		address:               backend.Address(),
+		logger:                log.New(),
+		backend:               backend,
+		backlogs:              make(map[tendermint.Validator]*prque.Prque),
+		pendingUnminedBlocks:  make(map[uint64]*types.Block),
+		pendingUnminedBlockCh: make(chan *types.Block),
+		valSet:                new(validatorSet),
+		futureRoundsChange:    make(map[int64]int64),
 	}
 	return c
 }
@@ -107,8 +107,11 @@ type core struct {
 
 	currentRoundState *roundState
 
-	pendingUnminedBlocks   *prque.Prque
-	pendingUnminedBlocksMu sync.Mutex
+	// map[Height]UnminedBlock
+	pendingUnminedBlocks     map[uint64]*types.Block
+	pendingUnminedBlocksMu   sync.Mutex
+	pendingUnminedBlockCh    chan *types.Block
+	isWaitingForUnminedBlock bool
 
 	sentProposal          bool
 	sentPrevote           bool
@@ -121,10 +124,6 @@ type core struct {
 	validValue  *types.Block
 
 	currentHeightRoundsStates map[int64]roundState
-
-	latestPendingUnminedBlock   *types.Block
-	latestPendingUnminedBlockMu sync.RWMutex
-	latestPendingUnminedBlockCh chan *types.Block
 
 	proposeTimeout   timeout
 	prevoteTimeout   timeout
@@ -187,7 +186,7 @@ func (c *core) broadcast(ctx context.Context, msg *message) {
 }
 
 func (c *core) isProposer() bool {
-	return c.valSet.IsProposer(c.backend.Address())
+	return c.valSet.IsProposer(c.address)
 }
 
 func (c *core) commit() {
@@ -278,18 +277,20 @@ func (c *core) startRound(ctx context.Context, round *big.Int) {
 
 	c.logger.Debug("Starting new Round", "Height", height, "Round", round)
 
-	// Wait for c.handleNewUnminedBlockEvent() go routine to update c.latestPendingUnminedBlock
-	// Only wait for new unmined block if latestPendingUnminedBlock is nil or fo previous height
-	c.checkLatestPendingUnminedBlock(ctx)
-
 	var p *types.Block
 	if c.isProposer() {
 		if c.validValue != nil {
 			p = c.validValue
 		} else {
-			c.latestPendingUnminedBlockMu.RLock()
-			p = c.latestPendingUnminedBlock
-			c.latestPendingUnminedBlockMu.RUnlock()
+			unmineBlock := c.getUnminedBlock()
+			p = unmineBlock
+			if p == nil {
+				select {
+				case <-ctx.Done():
+					return
+				case p = <-c.pendingUnminedBlockCh:
+				}
+			}
 		}
 		c.sendProposal(ctx, p)
 	} else {
@@ -301,39 +302,7 @@ func (c *core) startRound(ctx context.Context, round *big.Int) {
 
 func (c *core) setStep(step Step) {
 	c.currentRoundState.SetStep(step)
-
-	if step == propose {
-		c.processPendingUnminedBlock()
-	}
 	c.processBacklog()
-}
-
-func (c *core) checkLatestPendingUnminedBlock(ctx context.Context) {
-	c.latestPendingUnminedBlockMu.RLock()
-	isMined := c.latestPendingUnminedBlock == nil || c.latestPendingUnminedBlock.Number().Int64() != c.currentRoundState.Height().Int64()
-	c.latestPendingUnminedBlockMu.RUnlock()
-
-	c.logger.Debug("Waiting for c.latestPendingUnminedBlockCh", "isMined?", isMined)
-	if isMined {
-		select {
-		case <-ctx.Done():
-			return
-		case <-c.latestPendingUnminedBlockCh:
-			return
-		}
-	}
-}
-
-func (c *core) setLatestPendingUnminedBlock(b *types.Block) {
-	c.latestPendingUnminedBlockMu.Lock()
-	wasNilOrDiffHeight := c.latestPendingUnminedBlock == nil || c.latestPendingUnminedBlock.Number().Int64() != c.currentRoundState.Height().Int64()
-	c.latestPendingUnminedBlock = b
-	c.latestPendingUnminedBlockMu.Unlock()
-
-	c.logger.Debug("Sending to c.latestPendingUnminedBlockCh", "wasNilOrDiffHeight?", wasNilOrDiffHeight)
-	if wasNilOrDiffHeight {
-		c.latestPendingUnminedBlockCh <- b
-	}
 }
 
 func (c *core) stopFutureProposalTimer() {

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -22,7 +22,6 @@ import (
 	"runtime/debug"
 
 	"github.com/clearmatics/autonity/common"
-	"github.com/clearmatics/autonity/consensus"
 	"github.com/clearmatics/autonity/consensus/tendermint"
 )
 
@@ -100,19 +99,10 @@ func (c *core) handleNewUnminedBlockEvent() {
 
 	for e := range c.newUnminedBlockEventSub.Chan() {
 		c.logger.Debug("Started handling tendermint.NewUnminedBlockEvent")
+
 		newUnminedBlockEvent := e.Data.(tendermint.NewUnminedBlockEvent)
-
 		pb := &newUnminedBlockEvent.NewUnminedBlock
-
-		err := c.handleUnminedBlock(pb)
-		switch err {
-		case consensus.ErrFutureBlock:
-			c.storeUnminedBlockMsg(pb)
-		case nil:
-			//nothing to do
-		default:
-			c.logger.Error("core.handleNewUnminedBlockEvent Get message(NewUnminedBlockEvent) failed", "err", err)
-		}
+		c.storeUnminedBlockMsg(pb)
 
 		c.logger.Debug("Finished handling tendermint.NewUnminedBlockEvent")
 	}

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -136,7 +136,7 @@ func (c *core) handleConsensusEvents(ctx context.Context) {
 
 				c.logger.Debug("Started handling tendermint.MessageEvent")
 				if err := c.handleMsg(ctx, e.Payload); err != nil {
-					c.logger.Error("core.handleConsensusEvents Get message(MessageEvent) payload failed", "err", err)
+					c.logger.Debug("core.handleConsensusEvents Get message(MessageEvent) payload failed", "err", err)
 					c.logger.Debug("Finished handling tendermint.MessageEvent with ERROR", "err", err)
 					continue
 				}
@@ -147,14 +147,14 @@ func (c *core) handleConsensusEvents(ctx context.Context) {
 				c.logger.Debug("Started handling backlogEvent")
 				err := c.handleCheckedMsg(ctx, e.msg, e.src)
 				if err != nil {
-					c.logger.Error("core.handleConsensusEvents handleCheckedMsg message failed", "err", err)
+					c.logger.Debug("core.handleConsensusEvents handleCheckedMsg message failed", "err", err)
 					c.logger.Debug("Finished handling backlogEvent with ERROR", "err", err)
 					continue
 				}
 
 				p, err := e.msg.Payload()
 				if err != nil {
-					c.logger.Error("core.handleConsensusEvents Get message payload failed", "err", err)
+					c.logger.Debug("core.handleConsensusEvents Get message payload failed", "err", err)
 					c.logger.Debug("Finished handling backlogEvent with ERROR", "err", err)
 					continue
 				}

--- a/consensus/tendermint/core/unmined_block.go
+++ b/consensus/tendermint/core/unmined_block.go
@@ -49,7 +49,7 @@ func (c *core) updatePendingUnminedBlocks(unminedBlock *types.Block) {
 		heights = append(heights, h)
 	}
 	for _, ub := range heights {
-		if ub < uint64(c.currentRoundState.Height().Uint64()) {
+		if ub < c.currentRoundState.Height().Uint64() {
 			delete(c.pendingUnminedBlocks, ub)
 		}
 	}

--- a/consensus/tendermint/core/unmined_block.go
+++ b/consensus/tendermint/core/unmined_block.go
@@ -69,10 +69,11 @@ func (c *core) getUnminedBlock() *types.Block {
 
 	if ok {
 		return ub
-	} else {
-		c.isWaitingForUnminedBlock = true
-		return nil
 	}
+
+	c.isWaitingForUnminedBlock = true
+	return nil
+
 }
 
 // check request step


### PR DESCRIPTION
related to #136 

There was a data race issue, where, if the height was not updated in time, the NewUnminedBlock will put the new unmined block in the backlog and just after releasing the lock the consensus event goroutine will update the state and then there would be a deadlock, because there will not be another event to send to update the lastest pending block.

The approach here is to use a map(`map[height]*unmineBlock`) instead of a priority queue, this would allow us to keep updating the map without any interference with the consensuEvents go routine and when the consensusEvent go routine requires the unmined block it will call `getUnminedBlock()` and if a block is available then it would be returned otherwise it will wait on `c.pendingUnminedBlockCh` and this will be sent over when a `NewUnminedBlockEvent` happens.