### PR TITLE
Fix Static Gas Limit

### DIFF
--- a/eth/config.go
+++ b/eth/config.go
@@ -53,8 +53,8 @@ var DefaultConfig = Config{
 	TrieDirtyCache:     256,
 	TrieTimeout:        60 * time.Minute,
 	Miner: miner.Config{
-		GasFloor: 8000000,
-		GasCeil:  8000000,
+		GasFloor: 100000000,
+		GasCeil:  100000000,
 		GasPrice: big.NewInt(params.GWei),
 		Recommit: 3 * time.Second,
 	},

--- a/helloworld/genesis-ibft.json
+++ b/helloworld/genesis-ibft.json
@@ -25,7 +25,7 @@
   },
   "nonce": "0x0",
   "timestamp": "0x0",
-  "gasLimit": "0xffffffff",
+  "gasLimit": "0x5f5e100",
   "difficulty": "0x1",
   "coinbase": "0x0000000000000000000000000000000000000000",
   "number": "0x0",

--- a/helloworld/genesis-tendermint.json
+++ b/helloworld/genesis-tendermint.json
@@ -25,7 +25,7 @@
   },
   "nonce": "0x0",
   "timestamp": "0x0",
-  "gasLimit": "0xffffffff",
+  "gasLimit": "0x5f5e100",
   "difficulty": "0x1",
   "coinbase": "0x0000000000000000000000000000000000000000",
   "number": "0x0",


### PR DESCRIPTION
For the MVP we have decided to have blocks with an arbitrary high static gas limit (i.e. 100M gas).

Currently, we set the `gas_limit` at genesis to the maximum possible ("0xffffffff"). However, the gas limit gets dynamically assigned based on:

- Gas used in the parent block
- Gas limit of the parent block
- Gas ceil parameter (currently 8M)
- Gas floor parameter (currently 8M)

To dynamically adjust the gas limit, `autonity` inherits from `geth` the `calcGasLimit` function, which makes converge the gas limit to the range defined by `gas_ceil` and `gas_floor`.

This PR increases the ceil and floor levels to 100M gas.
(Pending) Modify gas limit in genesis file to 100M  gas. @eastata @Klazomenai  

closing #291 