### PR TITLE
Fix datarace

### DIFF
--- a/cmd/autonity/config.go
+++ b/cmd/autonity/config.go
@@ -179,6 +179,5 @@ func dumpConfig(ctx *cli.Context) error {
 		return err
 	}
 
-
 	return nil
 }

--- a/consensus/test/tendermint_test.go
+++ b/consensus/test/tendermint_test.go
@@ -1086,11 +1086,13 @@ func runTest(t *testing.T, test *testCase) {
 		i := i
 
 		wg.Go(func() error {
+			validator.node.Server().Lock.Lock()
 			log.Debug("peers", "i", i,
 				"peers", len(validator.node.Server().Peers()),
 				"staticPeers", len(validator.node.Server().StaticNodes),
 				"trustedPeers", len(validator.node.Server().TrustedNodes),
 				"nodes", len(validators))
+			validator.node.Server().Lock.Unlock()
 			return nil
 		})
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -292,7 +292,7 @@ func (pm *ProtocolManager) Stop() {
 	pm.txsSub.Unsubscribe()        // quits txBroadcastLoop
 	pm.minedBlockSub.Unsubscribe() // quits blockBroadcastLoop
 	if !pm.openNetwork {
-		pm.whitelistSub.Unsubscribe() // quits glienickeEventLoop
+		pm.whitelistSub.Unsubscribe() // quits autonityEventLoop
 	}
 
 	// Quit the sync loop.


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c01d871670 by goroutine 817:
  github.com/clearmatics/autonity/p2p.(*Server).UpdateWhitelist()
      /Users/boris/go/src/github.com/clearmatics/autonity/p2p/server.go:406 +0x772
  github.com/clearmatics/autonity/eth.(*Ethereum).glienickeEventLoop()
      /Users/boris/go/src/github.com/clearmatics/autonity/eth/backend.go:635 +0x71b

Previous read at 0x00c01d871670 by goroutine 398:
  github.com/clearmatics/autonity/consensus/test.runTest.func4()
      /Users/boris/go/src/github.com/clearmatics/autonity/consensus/test/tendermint_test.go:1091 +0xe4
  github.com/clearmatics/autonity/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/boris/go/src/github.com/clearmatics/autonity/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x71
```
