### PR TITLE
Fix for failed lookup at genesis init

### DIFF
--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -177,7 +177,7 @@ func parseComplete(rawurl string, resolve bool) (*Node, error) {
 
 		hostIPs, err := net.LookupIP(host)
 		if err != nil {
-			return nil, errors.New("invalid domain or IP address")
+			return NewV4(id, nil, 0, 0), errors.New("invalid domain or IP address")
 		}
 		if len(hostIPs) > 0 {
 			ip = hostIPs[len(hostIPs)-1]

--- a/params/autonity_contract.go
+++ b/params/autonity_contract.go
@@ -69,9 +69,12 @@ func (ac *AutonityContractGenesis) AddDefault() *AutonityContractGenesis {
 	}
 
 	for i := range ac.Users {
-		n, err := enode.ParseV4WithResolve(ac.Users[i].Enode)
-		if reflect.DeepEqual(ac.Users[i].Address, common.Address{}) && err == nil {
-			ac.Users[i].Address = EnodeToAddress(n)
+		if reflect.DeepEqual(ac.Users[i].Address, common.Address{}) {
+			if n, err := enode.ParseV4WithResolve(ac.Users[i].Enode); n != nil {
+				ac.Users[i].Address = EnodeToAddress(n)
+			} else {
+				log.Error("Error parsing enode", "enode", ac.Users[i].Enode, "err", err)
+			}
 		}
 	}
 	return ac
@@ -127,8 +130,8 @@ func (u *User) Validate() error {
 		return errors.New("if user.type is validator then user.enode must be defined")
 	}
 	if len(u.Enode) > 0 {
-		_, err := enode.ParseV4WithResolve(u.Enode)
-		if err != nil {
+		n, err := enode.ParseV4WithResolve(u.Enode)
+		if n == nil {
 			return fmt.Errorf("fail to parse enode for account %v, error:%v", u.Address, err)
 		}
 

--- a/params/version.go
+++ b/params/version.go
@@ -23,8 +23,8 @@ import (
 const (
 	VersionMajor = 0    // Major version component of the current release
 	VersionMinor = 2    // Minor version component of the current release
-	VersionPatch = 0    // Patch version component of the current release
-	VersionMeta  = "rc" // Version metadata to append to the version string
+	VersionPatch = 1    // Patch version component of the current release
+	VersionMeta  = "" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
## Problem

Under the following conditions:
- Missing address field in genesis json for an autonityContract user
- Networking stack not ready
- enode with a hostname

The lookup function will return an error while having a correct enode. This edge case is problematic with k8s deployment.

## Proposed solution

Return a node object if parsing is successful regardless of lookup status.
