### PR TITLE
[WIP] Extend Autonity Contract RPC

### DIFF
--- a/consensus/tendermint/backend/api.go
+++ b/consensus/tendermint/backend/api.go
@@ -19,9 +19,9 @@ package backend
 import (
 	"github.com/clearmatics/autonity/common"
 	"github.com/clearmatics/autonity/consensus/tendermint/core"
-	"github.com/clearmatics/autonity/rpc"
-	"github.com/clearmatics/autonity/params"
 	blockchain "github.com/clearmatics/autonity/core"
+	"github.com/clearmatics/autonity/params"
+	"github.com/clearmatics/autonity/rpc"
 )
 
 // API is a user facing RPC API to dump BFT state
@@ -99,4 +99,3 @@ func (api *API) GetValidatorsInfo() []params.User {
 func (api *API) GetStakeholdersInfo() []params.User {
 	return api.chain.Config().AutonityContractConfig.GetStakeHolderUsers()
 }
-

--- a/consensus/tendermint/backend/api.go
+++ b/consensus/tendermint/backend/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/clearmatics/autonity/consensus"
 	"github.com/clearmatics/autonity/consensus/tendermint/core"
 	"github.com/clearmatics/autonity/rpc"
+	"github.com/clearmatics/autonity/params"
 )
 
 // API is a user facing RPC API to dump BFT state
@@ -68,3 +69,29 @@ func (api *API) GetContractABI() string {
 func (api *API) GetWhitelist() []string {
 	return api.tendermint.WhiteList()
 }
+
+// Get minimum gas price
+func (api *API) GetMinGasPrice() uint64 {
+	return api.chain.Config().AutonityContractConfig.MinGasPrice
+}
+
+// Get System Operator Address
+func (api *API) GetSystemOperator() common.Address {
+	return api.chain.Config().AutonityContractConfig.Operator
+}
+
+// Get information from Autonity Users
+func (api *API) GetUsersInfo() []params.User {
+	return api.chain.Config().AutonityContractConfig.Users
+}
+
+// Get information from Autonity Validators
+func (api *API) GetValidatorsInfo() []params.User {
+	return api.chain.Config().AutonityContractConfig.GetValidatorUsers()
+}
+
+// Get information from Autonity Validators
+func (api *API) GetStakeholdersInfo() []params.User {
+	return api.chain.Config().AutonityContractConfig.GetStakeHolderUsers()
+}
+

--- a/consensus/tendermint/backend/api.go
+++ b/consensus/tendermint/backend/api.go
@@ -18,15 +18,15 @@ package backend
 
 import (
 	"github.com/clearmatics/autonity/common"
-	"github.com/clearmatics/autonity/consensus"
 	"github.com/clearmatics/autonity/consensus/tendermint/core"
 	"github.com/clearmatics/autonity/rpc"
 	"github.com/clearmatics/autonity/params"
+	blockchain "github.com/clearmatics/autonity/core"
 )
 
 // API is a user facing RPC API to dump BFT state
 type API struct {
-	chain      consensus.ChainReader
+	chain      blockchain.BlockChain
 	tendermint core.Backend
 }
 
@@ -71,8 +71,13 @@ func (api *API) GetWhitelist() []string {
 }
 
 // Get minimum gas price
-func (api *API) GetMinGasPrice() uint64 {
-	return api.chain.Config().AutonityContractConfig.MinGasPrice
+func (api *API) GetMinGasPrice() (uint64, error) {
+	currentBlock := api.chain.CurrentBlock()
+	state, err := api.chain.State()
+	if err != nil {
+		return 0, err
+	}
+	return api.chain.GetAutonityContract().GetMinimumGasPrice(currentBlock, state)
 }
 
 // Get System Operator Address

--- a/consensus/tendermint/backend/engine.go
+++ b/consensus/tendermint/backend/engine.go
@@ -517,7 +517,7 @@ func (sb *Backend) updateBlock(block *types.Block) (*types.Block, error) {
 // APIs returns the RPC APIs this consensus engine provides.
 func (sb *Backend) APIs(chain consensus.ChainReader) []rpc.API {
 	return []rpc.API{{
-		Namespace: "tendermint",
+		Namespace: "autonity",
 		Version:   "1.0",
 		Service:   &API{chain: chain, tendermint: sb},
 		Public:    true,

--- a/consensus/tendermint/backend/engine.go
+++ b/consensus/tendermint/backend/engine.go
@@ -516,10 +516,15 @@ func (sb *Backend) updateBlock(block *types.Block) (*types.Block, error) {
 
 // APIs returns the RPC APIs this consensus engine provides.
 func (sb *Backend) APIs(chain consensus.ChainReader) []rpc.API {
+	blockchain, ok := chain.(*core.BlockChain)
+	if !ok {
+		log.Info("API Error: ChainReader cast was not successful.")
+		return nil
+	}
 	return []rpc.API{{
 		Namespace: "autonity",
 		Version:   "1.0",
-		Service:   &API{chain: chain, tendermint: sb},
+		Service:   &API{chain: *blockchain, tendermint: sb},
 		Public:    true,
 	}}
 }

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -33,8 +33,7 @@ var Modules = map[string]string{
 	"swarmfs":    SwarmfsJs,
 	"txpool":     TxpoolJs,
 	"les":        LESJs,
-	"istanbul":   Istanbul_JS,
-	"tendermint": TendermintJs,
+	"autonity":   AutonityJs,
 }
 
 const ChequebookJs = `
@@ -809,90 +808,61 @@ web3._extend({
 });
 `
 
-const Istanbul_JS = `
+const AutonityJs = `
 web3._extend({
-	property: 'istanbul',
+	property: 'autonity',
 	methods:
 	[
 		new web3._extend.Method({
 			name: 'getValidators',
-			call: 'istanbul_getValidators',
+			call: 'autonity_getValidators',
 			params: 1
 		}),
 		new web3._extend.Method({
 			name: 'getValidatorsAtHash',
-			call: 'istanbul_getValidatorsAtHash',
+			call: 'autonity_getValidatorsAtHash',
 			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'getSomaContractAddress',
-			call: 'istanbul_getSomaContractAddress',
-			params: 0
-		}),
-		new web3._extend.Method({
-			name: 'getSomaContractABI',
-			call: 'istanbul_getSomaContractABI',
-			params: 0
-		}),
-		new web3._extend.Method({
-			name: 'getGlienickeContractAddress',
-			call: 'istanbul_getGlienickeContractAddress',
-			params: 0
-		}),
-		new web3._extend.Method({
-			name: 'getGlienickeContractABI',
-			call: 'istanbul_getGlienickeContractABI',
-			params: 0
 		}),
 		new web3._extend.Method({
 			name: 'getWhitelist',
-			call: 'istanbul_getWhitelist',
-			params: 0
-		})
-	]
-});
-`
-
-const TendermintJs = `
-web3._extend({
-	property: 'tendermint',
-	methods:
-	[
-		new web3._extend.Method({
-			name: 'getValidators',
-			call: 'tendermint_getValidators',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'getValidatorsAtHash',
-			call: 'tendermint_getValidatorsAtHash',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'getSomaContractAddress',
-			call: 'tendermint_getSomaContractAddress',
+			call: 'autonity_getWhitelist',
 			params: 0
 		}),
 		new web3._extend.Method({
-			name: 'getSomaContractABI',
-			call: 'tendermint_getSomaContractABI',
+			name: 'getContractAddress',
+			call: 'autonity_getContractAddress',
 			params: 0
 		}),
 		new web3._extend.Method({
-			name: 'getGlienickeContractAddress',
-			call: 'tendermint_getGlienickeContractAddress',
+			name: 'getContractABI',
+			call: 'autonity_getContractABI',
 			params: 0
 		}),
 		new web3._extend.Method({
-			name: 'getGlienickeContractABI',
-			call: 'tendermint_getGlienickeContractABI',
+			name: 'getMinGasPrice',
+			call: 'autonity_getMinGasPrice',
 			params: 0
 		}),
 		new web3._extend.Method({
-			name: 'getWhitelist',
-			call: 'tendermint_getWhitelist',
+			name: 'getSystemOperator',
+			call: 'autonity_getSystemOperator',
 			params: 0
-		})
+		}),
+		new web3._extend.Method({
+			name: 'getUsersInfo',
+			call: 'autonity_getUsersInfo',
+			params: 0
+		}),
+		new web3._extend.Method({
+			name: 'getValidatorsInfo',
+			call: 'autonity_getValidatorsInfo',
+			params: 0
+		}),
+		new web3._extend.Method({
+			name: 'getStakeholdersInfo',
+			call: 'autonity_getStakeholdersInfo',
+			params: 0
+		}),
 	]
 });
 `


### PR DESCRIPTION
The goal of these changes is to make Autonity, and the Autonity contract more user-friendly.

**Changes**

- Extend Autonity Contract RPC API.
- Add relevant Web3 methods.
- Rename namespace from Tendermint to Autonity.
- Remove deprecated references to Soma or Glienicke.