### PR TITLE
Sync pull msg discard fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test-deps:
 	cd tests/testdata && git checkout 6b85703b568f4456582a00665d8a3e5c3b20b484
 
 lint-deps:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./build/bin v1.16.0
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./build/bin v1.21.0
 
 clean:
 	./build/clean_go_build_cache.sh

--- a/consensus/consensus_mock.go
+++ b/consensus/consensus_mock.go
@@ -42,6 +42,7 @@ func (m *MockChainReader) EXPECT() *MockChainReaderMockRecorder {
 
 // Config mocks base method
 func (m *MockChainReader) Config() *params.ChainConfig {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config")
 	ret0, _ := ret[0].(*params.ChainConfig)
 	return ret0
@@ -49,11 +50,13 @@ func (m *MockChainReader) Config() *params.ChainConfig {
 
 // Config indicates an expected call of Config
 func (mr *MockChainReaderMockRecorder) Config() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockChainReader)(nil).Config))
 }
 
 // CurrentHeader mocks base method
 func (m *MockChainReader) CurrentHeader() *types.Header {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentHeader")
 	ret0, _ := ret[0].(*types.Header)
 	return ret0
@@ -61,11 +64,13 @@ func (m *MockChainReader) CurrentHeader() *types.Header {
 
 // CurrentHeader indicates an expected call of CurrentHeader
 func (mr *MockChainReaderMockRecorder) CurrentHeader() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentHeader", reflect.TypeOf((*MockChainReader)(nil).CurrentHeader))
 }
 
 // GetHeader mocks base method
 func (m *MockChainReader) GetHeader(hash common.Hash, number uint64) *types.Header {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHeader", hash, number)
 	ret0, _ := ret[0].(*types.Header)
 	return ret0
@@ -73,11 +78,13 @@ func (m *MockChainReader) GetHeader(hash common.Hash, number uint64) *types.Head
 
 // GetHeader indicates an expected call of GetHeader
 func (mr *MockChainReaderMockRecorder) GetHeader(hash, number interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeader", reflect.TypeOf((*MockChainReader)(nil).GetHeader), hash, number)
 }
 
 // GetHeaderByNumber mocks base method
 func (m *MockChainReader) GetHeaderByNumber(number uint64) *types.Header {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHeaderByNumber", number)
 	ret0, _ := ret[0].(*types.Header)
 	return ret0
@@ -85,11 +92,13 @@ func (m *MockChainReader) GetHeaderByNumber(number uint64) *types.Header {
 
 // GetHeaderByNumber indicates an expected call of GetHeaderByNumber
 func (mr *MockChainReaderMockRecorder) GetHeaderByNumber(number interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaderByNumber", reflect.TypeOf((*MockChainReader)(nil).GetHeaderByNumber), number)
 }
 
 // GetHeaderByHash mocks base method
 func (m *MockChainReader) GetHeaderByHash(hash common.Hash) *types.Header {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHeaderByHash", hash)
 	ret0, _ := ret[0].(*types.Header)
 	return ret0
@@ -97,11 +106,13 @@ func (m *MockChainReader) GetHeaderByHash(hash common.Hash) *types.Header {
 
 // GetHeaderByHash indicates an expected call of GetHeaderByHash
 func (mr *MockChainReaderMockRecorder) GetHeaderByHash(hash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaderByHash", reflect.TypeOf((*MockChainReader)(nil).GetHeaderByHash), hash)
 }
 
 // GetBlock mocks base method
 func (m *MockChainReader) GetBlock(hash common.Hash, number uint64) *types.Block {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlock", hash, number)
 	ret0, _ := ret[0].(*types.Block)
 	return ret0
@@ -109,11 +120,13 @@ func (m *MockChainReader) GetBlock(hash common.Hash, number uint64) *types.Block
 
 // GetBlock indicates an expected call of GetBlock
 func (mr *MockChainReaderMockRecorder) GetBlock(hash, number interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlock", reflect.TypeOf((*MockChainReader)(nil).GetBlock), hash, number)
 }
 
 // Engine mocks base method
 func (m *MockChainReader) Engine() Engine {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Engine")
 	ret0, _ := ret[0].(Engine)
 	return ret0
@@ -121,6 +134,7 @@ func (m *MockChainReader) Engine() Engine {
 
 // Engine indicates an expected call of Engine
 func (mr *MockChainReaderMockRecorder) Engine() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Engine", reflect.TypeOf((*MockChainReader)(nil).Engine))
 }
 
@@ -149,6 +163,7 @@ func (m *MockEngine) EXPECT() *MockEngineMockRecorder {
 
 // Author mocks base method
 func (m *MockEngine) Author(header *types.Header) (common.Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Author", header)
 	ret0, _ := ret[0].(common.Address)
 	ret1, _ := ret[1].(error)
@@ -157,11 +172,13 @@ func (m *MockEngine) Author(header *types.Header) (common.Address, error) {
 
 // Author indicates an expected call of Author
 func (mr *MockEngineMockRecorder) Author(header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Author", reflect.TypeOf((*MockEngine)(nil).Author), header)
 }
 
 // VerifyHeader mocks base method
 func (m *MockEngine) VerifyHeader(chain ChainReader, header *types.Header, seal bool) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyHeader", chain, header, seal)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -169,11 +186,13 @@ func (m *MockEngine) VerifyHeader(chain ChainReader, header *types.Header, seal 
 
 // VerifyHeader indicates an expected call of VerifyHeader
 func (mr *MockEngineMockRecorder) VerifyHeader(chain, header, seal interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyHeader", reflect.TypeOf((*MockEngine)(nil).VerifyHeader), chain, header, seal)
 }
 
 // VerifyHeaders mocks base method
 func (m *MockEngine) VerifyHeaders(chain ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyHeaders", chain, headers, seals)
 	ret0, _ := ret[0].(chan<- struct{})
 	ret1, _ := ret[1].(<-chan error)
@@ -182,11 +201,13 @@ func (m *MockEngine) VerifyHeaders(chain ChainReader, headers []*types.Header, s
 
 // VerifyHeaders indicates an expected call of VerifyHeaders
 func (mr *MockEngineMockRecorder) VerifyHeaders(chain, headers, seals interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyHeaders", reflect.TypeOf((*MockEngine)(nil).VerifyHeaders), chain, headers, seals)
 }
 
 // VerifyUncles mocks base method
 func (m *MockEngine) VerifyUncles(chain ChainReader, block *types.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyUncles", chain, block)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -194,11 +215,13 @@ func (m *MockEngine) VerifyUncles(chain ChainReader, block *types.Block) error {
 
 // VerifyUncles indicates an expected call of VerifyUncles
 func (mr *MockEngineMockRecorder) VerifyUncles(chain, block interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUncles", reflect.TypeOf((*MockEngine)(nil).VerifyUncles), chain, block)
 }
 
 // VerifySeal mocks base method
 func (m *MockEngine) VerifySeal(chain ChainReader, header *types.Header) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifySeal", chain, header)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -206,11 +229,13 @@ func (m *MockEngine) VerifySeal(chain ChainReader, header *types.Header) error {
 
 // VerifySeal indicates an expected call of VerifySeal
 func (mr *MockEngineMockRecorder) VerifySeal(chain, header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifySeal", reflect.TypeOf((*MockEngine)(nil).VerifySeal), chain, header)
 }
 
 // Prepare mocks base method
 func (m *MockEngine) Prepare(chain ChainReader, header *types.Header) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Prepare", chain, header)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -218,21 +243,25 @@ func (m *MockEngine) Prepare(chain ChainReader, header *types.Header) error {
 
 // Prepare indicates an expected call of Prepare
 func (mr *MockEngineMockRecorder) Prepare(chain, header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockEngine)(nil).Prepare), chain, header)
 }
 
 // Finalize mocks base method
 func (m *MockEngine) Finalize(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Finalize", chain, header, state, txs, uncles)
 }
 
 // Finalize indicates an expected call of Finalize
 func (mr *MockEngineMockRecorder) Finalize(chain, header, state, txs, uncles interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finalize", reflect.TypeOf((*MockEngine)(nil).Finalize), chain, header, state, txs, uncles)
 }
 
 // FinalizeAndAssemble mocks base method
 func (m *MockEngine) FinalizeAndAssemble(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FinalizeAndAssemble", chain, header, state, txs, uncles, receipts)
 	ret0, _ := ret[0].(*types.Block)
 	ret1, _ := ret[1].(error)
@@ -241,11 +270,13 @@ func (m *MockEngine) FinalizeAndAssemble(chain ChainReader, header *types.Header
 
 // FinalizeAndAssemble indicates an expected call of FinalizeAndAssemble
 func (mr *MockEngineMockRecorder) FinalizeAndAssemble(chain, header, state, txs, uncles, receipts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeAndAssemble", reflect.TypeOf((*MockEngine)(nil).FinalizeAndAssemble), chain, header, state, txs, uncles, receipts)
 }
 
 // Seal mocks base method
 func (m *MockEngine) Seal(chain ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Seal", chain, block, results, stop)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -253,11 +284,13 @@ func (m *MockEngine) Seal(chain ChainReader, block *types.Block, results chan<- 
 
 // Seal indicates an expected call of Seal
 func (mr *MockEngineMockRecorder) Seal(chain, block, results, stop interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seal", reflect.TypeOf((*MockEngine)(nil).Seal), chain, block, results, stop)
 }
 
 // SealHash mocks base method
 func (m *MockEngine) SealHash(header *types.Header) common.Hash {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SealHash", header)
 	ret0, _ := ret[0].(common.Hash)
 	return ret0
@@ -265,11 +298,13 @@ func (m *MockEngine) SealHash(header *types.Header) common.Hash {
 
 // SealHash indicates an expected call of SealHash
 func (mr *MockEngineMockRecorder) SealHash(header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SealHash", reflect.TypeOf((*MockEngine)(nil).SealHash), header)
 }
 
 // CalcDifficulty mocks base method
 func (m *MockEngine) CalcDifficulty(chain ChainReader, time uint64, parent *types.Header) *big.Int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcDifficulty", chain, time, parent)
 	ret0, _ := ret[0].(*big.Int)
 	return ret0
@@ -277,11 +312,13 @@ func (m *MockEngine) CalcDifficulty(chain ChainReader, time uint64, parent *type
 
 // CalcDifficulty indicates an expected call of CalcDifficulty
 func (mr *MockEngineMockRecorder) CalcDifficulty(chain, time, parent interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcDifficulty", reflect.TypeOf((*MockEngine)(nil).CalcDifficulty), chain, time, parent)
 }
 
 // APIs mocks base method
 func (m *MockEngine) APIs(chain ChainReader) []rpc.API {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIs", chain)
 	ret0, _ := ret[0].([]rpc.API)
 	return ret0
@@ -289,11 +326,13 @@ func (m *MockEngine) APIs(chain ChainReader) []rpc.API {
 
 // APIs indicates an expected call of APIs
 func (mr *MockEngineMockRecorder) APIs(chain interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIs", reflect.TypeOf((*MockEngine)(nil).APIs), chain)
 }
 
 // Close mocks base method
 func (m *MockEngine) Close() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -301,6 +340,7 @@ func (m *MockEngine) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockEngineMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockEngine)(nil).Close))
 }
 
@@ -329,6 +369,7 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 
 // NewChainHead mocks base method
 func (m *MockHandler) NewChainHead() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewChainHead")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -336,11 +377,13 @@ func (m *MockHandler) NewChainHead() error {
 
 // NewChainHead indicates an expected call of NewChainHead
 func (mr *MockHandlerMockRecorder) NewChainHead() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewChainHead", reflect.TypeOf((*MockHandler)(nil).NewChainHead))
 }
 
 // HandleMsg mocks base method
 func (m *MockHandler) HandleMsg(address common.Address, data p2p.Msg) (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleMsg", address, data)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -349,21 +392,25 @@ func (m *MockHandler) HandleMsg(address common.Address, data p2p.Msg) (bool, err
 
 // HandleMsg indicates an expected call of HandleMsg
 func (mr *MockHandlerMockRecorder) HandleMsg(address, data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleMsg", reflect.TypeOf((*MockHandler)(nil).HandleMsg), address, data)
 }
 
 // SetBroadcaster mocks base method
 func (m *MockHandler) SetBroadcaster(arg0 Broadcaster) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetBroadcaster", arg0)
 }
 
 // SetBroadcaster indicates an expected call of SetBroadcaster
 func (mr *MockHandlerMockRecorder) SetBroadcaster(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBroadcaster", reflect.TypeOf((*MockHandler)(nil).SetBroadcaster), arg0)
 }
 
 // Protocol mocks base method
 func (m *MockHandler) Protocol() (string, uint64) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Protocol")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(uint64)
@@ -372,6 +419,7 @@ func (m *MockHandler) Protocol() (string, uint64) {
 
 // Protocol indicates an expected call of Protocol
 func (mr *MockHandlerMockRecorder) Protocol() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Protocol", reflect.TypeOf((*MockHandler)(nil).Protocol))
 }
 
@@ -400,6 +448,7 @@ func (m *MockPoW) EXPECT() *MockPoWMockRecorder {
 
 // Author mocks base method
 func (m *MockPoW) Author(header *types.Header) (common.Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Author", header)
 	ret0, _ := ret[0].(common.Address)
 	ret1, _ := ret[1].(error)
@@ -408,11 +457,13 @@ func (m *MockPoW) Author(header *types.Header) (common.Address, error) {
 
 // Author indicates an expected call of Author
 func (mr *MockPoWMockRecorder) Author(header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Author", reflect.TypeOf((*MockPoW)(nil).Author), header)
 }
 
 // VerifyHeader mocks base method
 func (m *MockPoW) VerifyHeader(chain ChainReader, header *types.Header, seal bool) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyHeader", chain, header, seal)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -420,11 +471,13 @@ func (m *MockPoW) VerifyHeader(chain ChainReader, header *types.Header, seal boo
 
 // VerifyHeader indicates an expected call of VerifyHeader
 func (mr *MockPoWMockRecorder) VerifyHeader(chain, header, seal interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyHeader", reflect.TypeOf((*MockPoW)(nil).VerifyHeader), chain, header, seal)
 }
 
 // VerifyHeaders mocks base method
 func (m *MockPoW) VerifyHeaders(chain ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyHeaders", chain, headers, seals)
 	ret0, _ := ret[0].(chan<- struct{})
 	ret1, _ := ret[1].(<-chan error)
@@ -433,11 +486,13 @@ func (m *MockPoW) VerifyHeaders(chain ChainReader, headers []*types.Header, seal
 
 // VerifyHeaders indicates an expected call of VerifyHeaders
 func (mr *MockPoWMockRecorder) VerifyHeaders(chain, headers, seals interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyHeaders", reflect.TypeOf((*MockPoW)(nil).VerifyHeaders), chain, headers, seals)
 }
 
 // VerifyUncles mocks base method
 func (m *MockPoW) VerifyUncles(chain ChainReader, block *types.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyUncles", chain, block)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -445,11 +500,13 @@ func (m *MockPoW) VerifyUncles(chain ChainReader, block *types.Block) error {
 
 // VerifyUncles indicates an expected call of VerifyUncles
 func (mr *MockPoWMockRecorder) VerifyUncles(chain, block interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUncles", reflect.TypeOf((*MockPoW)(nil).VerifyUncles), chain, block)
 }
 
 // VerifySeal mocks base method
 func (m *MockPoW) VerifySeal(chain ChainReader, header *types.Header) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifySeal", chain, header)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -457,11 +514,13 @@ func (m *MockPoW) VerifySeal(chain ChainReader, header *types.Header) error {
 
 // VerifySeal indicates an expected call of VerifySeal
 func (mr *MockPoWMockRecorder) VerifySeal(chain, header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifySeal", reflect.TypeOf((*MockPoW)(nil).VerifySeal), chain, header)
 }
 
 // Prepare mocks base method
 func (m *MockPoW) Prepare(chain ChainReader, header *types.Header) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Prepare", chain, header)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -469,21 +528,25 @@ func (m *MockPoW) Prepare(chain ChainReader, header *types.Header) error {
 
 // Prepare indicates an expected call of Prepare
 func (mr *MockPoWMockRecorder) Prepare(chain, header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockPoW)(nil).Prepare), chain, header)
 }
 
 // Finalize mocks base method
 func (m *MockPoW) Finalize(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Finalize", chain, header, state, txs, uncles)
 }
 
 // Finalize indicates an expected call of Finalize
 func (mr *MockPoWMockRecorder) Finalize(chain, header, state, txs, uncles interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finalize", reflect.TypeOf((*MockPoW)(nil).Finalize), chain, header, state, txs, uncles)
 }
 
 // FinalizeAndAssemble mocks base method
 func (m *MockPoW) FinalizeAndAssemble(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FinalizeAndAssemble", chain, header, state, txs, uncles, receipts)
 	ret0, _ := ret[0].(*types.Block)
 	ret1, _ := ret[1].(error)
@@ -492,11 +555,13 @@ func (m *MockPoW) FinalizeAndAssemble(chain ChainReader, header *types.Header, s
 
 // FinalizeAndAssemble indicates an expected call of FinalizeAndAssemble
 func (mr *MockPoWMockRecorder) FinalizeAndAssemble(chain, header, state, txs, uncles, receipts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeAndAssemble", reflect.TypeOf((*MockPoW)(nil).FinalizeAndAssemble), chain, header, state, txs, uncles, receipts)
 }
 
 // Seal mocks base method
 func (m *MockPoW) Seal(chain ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Seal", chain, block, results, stop)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -504,11 +569,13 @@ func (m *MockPoW) Seal(chain ChainReader, block *types.Block, results chan<- *ty
 
 // Seal indicates an expected call of Seal
 func (mr *MockPoWMockRecorder) Seal(chain, block, results, stop interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seal", reflect.TypeOf((*MockPoW)(nil).Seal), chain, block, results, stop)
 }
 
 // SealHash mocks base method
 func (m *MockPoW) SealHash(header *types.Header) common.Hash {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SealHash", header)
 	ret0, _ := ret[0].(common.Hash)
 	return ret0
@@ -516,11 +583,13 @@ func (m *MockPoW) SealHash(header *types.Header) common.Hash {
 
 // SealHash indicates an expected call of SealHash
 func (mr *MockPoWMockRecorder) SealHash(header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SealHash", reflect.TypeOf((*MockPoW)(nil).SealHash), header)
 }
 
 // CalcDifficulty mocks base method
 func (m *MockPoW) CalcDifficulty(chain ChainReader, time uint64, parent *types.Header) *big.Int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcDifficulty", chain, time, parent)
 	ret0, _ := ret[0].(*big.Int)
 	return ret0
@@ -528,11 +597,13 @@ func (m *MockPoW) CalcDifficulty(chain ChainReader, time uint64, parent *types.H
 
 // CalcDifficulty indicates an expected call of CalcDifficulty
 func (mr *MockPoWMockRecorder) CalcDifficulty(chain, time, parent interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcDifficulty", reflect.TypeOf((*MockPoW)(nil).CalcDifficulty), chain, time, parent)
 }
 
 // APIs mocks base method
 func (m *MockPoW) APIs(chain ChainReader) []rpc.API {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIs", chain)
 	ret0, _ := ret[0].([]rpc.API)
 	return ret0
@@ -540,11 +611,13 @@ func (m *MockPoW) APIs(chain ChainReader) []rpc.API {
 
 // APIs indicates an expected call of APIs
 func (mr *MockPoWMockRecorder) APIs(chain interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIs", reflect.TypeOf((*MockPoW)(nil).APIs), chain)
 }
 
 // Close mocks base method
 func (m *MockPoW) Close() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -552,11 +625,13 @@ func (m *MockPoW) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockPoWMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockPoW)(nil).Close))
 }
 
 // Hashrate mocks base method
 func (m *MockPoW) Hashrate() float64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Hashrate")
 	ret0, _ := ret[0].(float64)
 	return ret0
@@ -564,6 +639,7 @@ func (m *MockPoW) Hashrate() float64 {
 
 // Hashrate indicates an expected call of Hashrate
 func (mr *MockPoWMockRecorder) Hashrate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Hashrate", reflect.TypeOf((*MockPoW)(nil).Hashrate))
 }
 
@@ -592,6 +668,7 @@ func (m *MockBFT) EXPECT() *MockBFTMockRecorder {
 
 // Author mocks base method
 func (m *MockBFT) Author(header *types.Header) (common.Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Author", header)
 	ret0, _ := ret[0].(common.Address)
 	ret1, _ := ret[1].(error)
@@ -600,11 +677,13 @@ func (m *MockBFT) Author(header *types.Header) (common.Address, error) {
 
 // Author indicates an expected call of Author
 func (mr *MockBFTMockRecorder) Author(header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Author", reflect.TypeOf((*MockBFT)(nil).Author), header)
 }
 
 // VerifyHeader mocks base method
 func (m *MockBFT) VerifyHeader(chain ChainReader, header *types.Header, seal bool) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyHeader", chain, header, seal)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -612,11 +691,13 @@ func (m *MockBFT) VerifyHeader(chain ChainReader, header *types.Header, seal boo
 
 // VerifyHeader indicates an expected call of VerifyHeader
 func (mr *MockBFTMockRecorder) VerifyHeader(chain, header, seal interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyHeader", reflect.TypeOf((*MockBFT)(nil).VerifyHeader), chain, header, seal)
 }
 
 // VerifyHeaders mocks base method
 func (m *MockBFT) VerifyHeaders(chain ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyHeaders", chain, headers, seals)
 	ret0, _ := ret[0].(chan<- struct{})
 	ret1, _ := ret[1].(<-chan error)
@@ -625,11 +706,13 @@ func (m *MockBFT) VerifyHeaders(chain ChainReader, headers []*types.Header, seal
 
 // VerifyHeaders indicates an expected call of VerifyHeaders
 func (mr *MockBFTMockRecorder) VerifyHeaders(chain, headers, seals interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyHeaders", reflect.TypeOf((*MockBFT)(nil).VerifyHeaders), chain, headers, seals)
 }
 
 // VerifyUncles mocks base method
 func (m *MockBFT) VerifyUncles(chain ChainReader, block *types.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyUncles", chain, block)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -637,11 +720,13 @@ func (m *MockBFT) VerifyUncles(chain ChainReader, block *types.Block) error {
 
 // VerifyUncles indicates an expected call of VerifyUncles
 func (mr *MockBFTMockRecorder) VerifyUncles(chain, block interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUncles", reflect.TypeOf((*MockBFT)(nil).VerifyUncles), chain, block)
 }
 
 // VerifySeal mocks base method
 func (m *MockBFT) VerifySeal(chain ChainReader, header *types.Header) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifySeal", chain, header)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -649,11 +734,13 @@ func (m *MockBFT) VerifySeal(chain ChainReader, header *types.Header) error {
 
 // VerifySeal indicates an expected call of VerifySeal
 func (mr *MockBFTMockRecorder) VerifySeal(chain, header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifySeal", reflect.TypeOf((*MockBFT)(nil).VerifySeal), chain, header)
 }
 
 // Prepare mocks base method
 func (m *MockBFT) Prepare(chain ChainReader, header *types.Header) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Prepare", chain, header)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -661,21 +748,25 @@ func (m *MockBFT) Prepare(chain ChainReader, header *types.Header) error {
 
 // Prepare indicates an expected call of Prepare
 func (mr *MockBFTMockRecorder) Prepare(chain, header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockBFT)(nil).Prepare), chain, header)
 }
 
 // Finalize mocks base method
 func (m *MockBFT) Finalize(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Finalize", chain, header, state, txs, uncles)
 }
 
 // Finalize indicates an expected call of Finalize
 func (mr *MockBFTMockRecorder) Finalize(chain, header, state, txs, uncles interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finalize", reflect.TypeOf((*MockBFT)(nil).Finalize), chain, header, state, txs, uncles)
 }
 
 // FinalizeAndAssemble mocks base method
 func (m *MockBFT) FinalizeAndAssemble(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FinalizeAndAssemble", chain, header, state, txs, uncles, receipts)
 	ret0, _ := ret[0].(*types.Block)
 	ret1, _ := ret[1].(error)
@@ -684,11 +775,13 @@ func (m *MockBFT) FinalizeAndAssemble(chain ChainReader, header *types.Header, s
 
 // FinalizeAndAssemble indicates an expected call of FinalizeAndAssemble
 func (mr *MockBFTMockRecorder) FinalizeAndAssemble(chain, header, state, txs, uncles, receipts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeAndAssemble", reflect.TypeOf((*MockBFT)(nil).FinalizeAndAssemble), chain, header, state, txs, uncles, receipts)
 }
 
 // Seal mocks base method
 func (m *MockBFT) Seal(chain ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Seal", chain, block, results, stop)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -696,11 +789,13 @@ func (m *MockBFT) Seal(chain ChainReader, block *types.Block, results chan<- *ty
 
 // Seal indicates an expected call of Seal
 func (mr *MockBFTMockRecorder) Seal(chain, block, results, stop interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seal", reflect.TypeOf((*MockBFT)(nil).Seal), chain, block, results, stop)
 }
 
 // SealHash mocks base method
 func (m *MockBFT) SealHash(header *types.Header) common.Hash {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SealHash", header)
 	ret0, _ := ret[0].(common.Hash)
 	return ret0
@@ -708,11 +803,13 @@ func (m *MockBFT) SealHash(header *types.Header) common.Hash {
 
 // SealHash indicates an expected call of SealHash
 func (mr *MockBFTMockRecorder) SealHash(header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SealHash", reflect.TypeOf((*MockBFT)(nil).SealHash), header)
 }
 
 // CalcDifficulty mocks base method
 func (m *MockBFT) CalcDifficulty(chain ChainReader, time uint64, parent *types.Header) *big.Int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcDifficulty", chain, time, parent)
 	ret0, _ := ret[0].(*big.Int)
 	return ret0
@@ -720,11 +817,13 @@ func (m *MockBFT) CalcDifficulty(chain ChainReader, time uint64, parent *types.H
 
 // CalcDifficulty indicates an expected call of CalcDifficulty
 func (mr *MockBFTMockRecorder) CalcDifficulty(chain, time, parent interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcDifficulty", reflect.TypeOf((*MockBFT)(nil).CalcDifficulty), chain, time, parent)
 }
 
 // APIs mocks base method
 func (m *MockBFT) APIs(chain ChainReader) []rpc.API {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIs", chain)
 	ret0, _ := ret[0].([]rpc.API)
 	return ret0
@@ -732,11 +831,13 @@ func (m *MockBFT) APIs(chain ChainReader) []rpc.API {
 
 // APIs indicates an expected call of APIs
 func (mr *MockBFTMockRecorder) APIs(chain interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIs", reflect.TypeOf((*MockBFT)(nil).APIs), chain)
 }
 
 // Close mocks base method
 func (m *MockBFT) Close() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -744,11 +845,13 @@ func (m *MockBFT) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockBFTMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockBFT)(nil).Close))
 }
 
 // Start mocks base method
 func (m *MockBFT) Start(ctx context.Context, chain ChainReader, currentBlock func() *types.Block, hasBadBlock func(common.Hash) bool) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", ctx, chain, currentBlock, hasBadBlock)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -756,6 +859,7 @@ func (m *MockBFT) Start(ctx context.Context, chain ChainReader, currentBlock fun
 
 // Start indicates an expected call of Start
 func (mr *MockBFTMockRecorder) Start(ctx, chain, currentBlock, hasBadBlock interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockBFT)(nil).Start), ctx, chain, currentBlock, hasBadBlock)
 }
 
@@ -784,20 +888,24 @@ func (m *MockSyncer) EXPECT() *MockSyncerMockRecorder {
 
 // SyncPeer mocks base method
 func (m *MockSyncer) SyncPeer(address common.Address) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SyncPeer", address)
 }
 
 // SyncPeer indicates an expected call of SyncPeer
 func (mr *MockSyncerMockRecorder) SyncPeer(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncPeer", reflect.TypeOf((*MockSyncer)(nil).SyncPeer), address)
 }
 
 // ResetPeerCache mocks base method
 func (m *MockSyncer) ResetPeerCache(address common.Address) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ResetPeerCache", address)
 }
 
 // ResetPeerCache indicates an expected call of ResetPeerCache
 func (mr *MockSyncerMockRecorder) ResetPeerCache(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetPeerCache", reflect.TypeOf((*MockSyncer)(nil).ResetPeerCache), address)
 }

--- a/consensus/protocol_mock.go
+++ b/consensus/protocol_mock.go
@@ -36,16 +36,19 @@ func (m *MockBroadcaster) EXPECT() *MockBroadcasterMockRecorder {
 
 // Enqueue mocks base method
 func (m *MockBroadcaster) Enqueue(id string, block *types.Block) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Enqueue", id, block)
 }
 
 // Enqueue indicates an expected call of Enqueue
 func (mr *MockBroadcasterMockRecorder) Enqueue(id, block interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enqueue", reflect.TypeOf((*MockBroadcaster)(nil).Enqueue), id, block)
 }
 
 // FindPeers mocks base method
 func (m *MockBroadcaster) FindPeers(arg0 map[common.Address]struct{}) map[common.Address]Peer {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindPeers", arg0)
 	ret0, _ := ret[0].(map[common.Address]Peer)
 	return ret0
@@ -53,6 +56,7 @@ func (m *MockBroadcaster) FindPeers(arg0 map[common.Address]struct{}) map[common
 
 // FindPeers indicates an expected call of FindPeers
 func (mr *MockBroadcasterMockRecorder) FindPeers(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindPeers", reflect.TypeOf((*MockBroadcaster)(nil).FindPeers), arg0)
 }
 
@@ -81,6 +85,7 @@ func (m *MockPeer) EXPECT() *MockPeerMockRecorder {
 
 // Send mocks base method
 func (m *MockPeer) Send(msgcode uint64, data interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Send", msgcode, data)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -88,5 +93,6 @@ func (m *MockPeer) Send(msgcode uint64, data interface{}) error {
 
 // Send indicates an expected call of Send
 func (mr *MockPeerMockRecorder) Send(msgcode, data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockPeer)(nil).Send), msgcode, data)
 }

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -102,16 +102,17 @@ func New(config *tendermintConfig.Config, privateKey *ecdsa.PrivateKey, db ethdb
 // ----------------------------------------------------------------------------
 
 type Backend struct {
-	config       *tendermintConfig.Config
-	eventMux     *event.TypeMuxSilent
-	privateKey   *ecdsa.PrivateKey
-	privateKeyMu sync.RWMutex
-	address      common.Address
-	logger       log.Logger
-	db           ethdb.Database
-	blockchain   *core.BlockChain
-	currentBlock func() *types.Block
-	hasBadBlock  func(hash common.Hash) bool
+	config           *tendermintConfig.Config
+	eventMux         *event.TypeMuxSilent
+	privateKey       *ecdsa.PrivateKey
+	privateKeyMu     sync.RWMutex
+	address          common.Address
+	logger           log.Logger
+	db               ethdb.Database
+	blockchain       *core.BlockChain
+	blockchainInitMu sync.Mutex
+	currentBlock     func() *types.Block
+	hasBadBlock      func(hash common.Hash) bool
 
 	// the channels for tendermint engine notifications
 	commitCh          chan<- *types.Block

--- a/consensus/tendermint/core/backend_mock.go
+++ b/consensus/tendermint/core/backend_mock.go
@@ -45,6 +45,7 @@ func (m *MockBackend) EXPECT() *MockBackendMockRecorder {
 
 // Author mocks base method
 func (m *MockBackend) Author(header *types.Header) (common.Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Author", header)
 	ret0, _ := ret[0].(common.Address)
 	ret1, _ := ret[1].(error)
@@ -53,11 +54,13 @@ func (m *MockBackend) Author(header *types.Header) (common.Address, error) {
 
 // Author indicates an expected call of Author
 func (mr *MockBackendMockRecorder) Author(header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Author", reflect.TypeOf((*MockBackend)(nil).Author), header)
 }
 
 // VerifyHeader mocks base method
 func (m *MockBackend) VerifyHeader(chain consensus.ChainReader, header *types.Header, seal bool) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyHeader", chain, header, seal)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -65,11 +68,13 @@ func (m *MockBackend) VerifyHeader(chain consensus.ChainReader, header *types.He
 
 // VerifyHeader indicates an expected call of VerifyHeader
 func (mr *MockBackendMockRecorder) VerifyHeader(chain, header, seal interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyHeader", reflect.TypeOf((*MockBackend)(nil).VerifyHeader), chain, header, seal)
 }
 
 // VerifyHeaders mocks base method
 func (m *MockBackend) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyHeaders", chain, headers, seals)
 	ret0, _ := ret[0].(chan<- struct{})
 	ret1, _ := ret[1].(<-chan error)
@@ -78,11 +83,13 @@ func (m *MockBackend) VerifyHeaders(chain consensus.ChainReader, headers []*type
 
 // VerifyHeaders indicates an expected call of VerifyHeaders
 func (mr *MockBackendMockRecorder) VerifyHeaders(chain, headers, seals interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyHeaders", reflect.TypeOf((*MockBackend)(nil).VerifyHeaders), chain, headers, seals)
 }
 
 // VerifyUncles mocks base method
 func (m *MockBackend) VerifyUncles(chain consensus.ChainReader, block *types.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyUncles", chain, block)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -90,11 +97,13 @@ func (m *MockBackend) VerifyUncles(chain consensus.ChainReader, block *types.Blo
 
 // VerifyUncles indicates an expected call of VerifyUncles
 func (mr *MockBackendMockRecorder) VerifyUncles(chain, block interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUncles", reflect.TypeOf((*MockBackend)(nil).VerifyUncles), chain, block)
 }
 
 // VerifySeal mocks base method
 func (m *MockBackend) VerifySeal(chain consensus.ChainReader, header *types.Header) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifySeal", chain, header)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -102,11 +111,13 @@ func (m *MockBackend) VerifySeal(chain consensus.ChainReader, header *types.Head
 
 // VerifySeal indicates an expected call of VerifySeal
 func (mr *MockBackendMockRecorder) VerifySeal(chain, header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifySeal", reflect.TypeOf((*MockBackend)(nil).VerifySeal), chain, header)
 }
 
 // Prepare mocks base method
 func (m *MockBackend) Prepare(chain consensus.ChainReader, header *types.Header) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Prepare", chain, header)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -114,21 +125,25 @@ func (m *MockBackend) Prepare(chain consensus.ChainReader, header *types.Header)
 
 // Prepare indicates an expected call of Prepare
 func (mr *MockBackendMockRecorder) Prepare(chain, header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockBackend)(nil).Prepare), chain, header)
 }
 
 // Finalize mocks base method
 func (m *MockBackend) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Finalize", chain, header, state, txs, uncles)
 }
 
 // Finalize indicates an expected call of Finalize
 func (mr *MockBackendMockRecorder) Finalize(chain, header, state, txs, uncles interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finalize", reflect.TypeOf((*MockBackend)(nil).Finalize), chain, header, state, txs, uncles)
 }
 
 // FinalizeAndAssemble mocks base method
 func (m *MockBackend) FinalizeAndAssemble(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FinalizeAndAssemble", chain, header, state, txs, uncles, receipts)
 	ret0, _ := ret[0].(*types.Block)
 	ret1, _ := ret[1].(error)
@@ -137,11 +152,13 @@ func (m *MockBackend) FinalizeAndAssemble(chain consensus.ChainReader, header *t
 
 // FinalizeAndAssemble indicates an expected call of FinalizeAndAssemble
 func (mr *MockBackendMockRecorder) FinalizeAndAssemble(chain, header, state, txs, uncles, receipts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeAndAssemble", reflect.TypeOf((*MockBackend)(nil).FinalizeAndAssemble), chain, header, state, txs, uncles, receipts)
 }
 
 // Seal mocks base method
 func (m *MockBackend) Seal(chain consensus.ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Seal", chain, block, results, stop)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -149,11 +166,13 @@ func (m *MockBackend) Seal(chain consensus.ChainReader, block *types.Block, resu
 
 // Seal indicates an expected call of Seal
 func (mr *MockBackendMockRecorder) Seal(chain, block, results, stop interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seal", reflect.TypeOf((*MockBackend)(nil).Seal), chain, block, results, stop)
 }
 
 // SealHash mocks base method
 func (m *MockBackend) SealHash(header *types.Header) common.Hash {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SealHash", header)
 	ret0, _ := ret[0].(common.Hash)
 	return ret0
@@ -161,11 +180,13 @@ func (m *MockBackend) SealHash(header *types.Header) common.Hash {
 
 // SealHash indicates an expected call of SealHash
 func (mr *MockBackendMockRecorder) SealHash(header interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SealHash", reflect.TypeOf((*MockBackend)(nil).SealHash), header)
 }
 
 // CalcDifficulty mocks base method
 func (m *MockBackend) CalcDifficulty(chain consensus.ChainReader, time uint64, parent *types.Header) *big.Int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcDifficulty", chain, time, parent)
 	ret0, _ := ret[0].(*big.Int)
 	return ret0
@@ -173,11 +194,13 @@ func (m *MockBackend) CalcDifficulty(chain consensus.ChainReader, time uint64, p
 
 // CalcDifficulty indicates an expected call of CalcDifficulty
 func (mr *MockBackendMockRecorder) CalcDifficulty(chain, time, parent interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcDifficulty", reflect.TypeOf((*MockBackend)(nil).CalcDifficulty), chain, time, parent)
 }
 
 // APIs mocks base method
 func (m *MockBackend) APIs(chain consensus.ChainReader) []rpc.API {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIs", chain)
 	ret0, _ := ret[0].([]rpc.API)
 	return ret0
@@ -185,11 +208,13 @@ func (m *MockBackend) APIs(chain consensus.ChainReader) []rpc.API {
 
 // APIs indicates an expected call of APIs
 func (mr *MockBackendMockRecorder) APIs(chain interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIs", reflect.TypeOf((*MockBackend)(nil).APIs), chain)
 }
 
 // Close mocks base method
 func (m *MockBackend) Close() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -197,11 +222,13 @@ func (m *MockBackend) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockBackendMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockBackend)(nil).Close))
 }
 
 // NewChainHead mocks base method
 func (m *MockBackend) NewChainHead() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewChainHead")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -209,11 +236,13 @@ func (m *MockBackend) NewChainHead() error {
 
 // NewChainHead indicates an expected call of NewChainHead
 func (mr *MockBackendMockRecorder) NewChainHead() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewChainHead", reflect.TypeOf((*MockBackend)(nil).NewChainHead))
 }
 
 // HandleMsg mocks base method
 func (m *MockBackend) HandleMsg(address common.Address, data p2p.Msg) (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleMsg", address, data)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -222,21 +251,25 @@ func (m *MockBackend) HandleMsg(address common.Address, data p2p.Msg) (bool, err
 
 // HandleMsg indicates an expected call of HandleMsg
 func (mr *MockBackendMockRecorder) HandleMsg(address, data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleMsg", reflect.TypeOf((*MockBackend)(nil).HandleMsg), address, data)
 }
 
 // SetBroadcaster mocks base method
 func (m *MockBackend) SetBroadcaster(arg0 consensus.Broadcaster) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetBroadcaster", arg0)
 }
 
 // SetBroadcaster indicates an expected call of SetBroadcaster
 func (mr *MockBackendMockRecorder) SetBroadcaster(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBroadcaster", reflect.TypeOf((*MockBackend)(nil).SetBroadcaster), arg0)
 }
 
 // Protocol mocks base method
 func (m *MockBackend) Protocol() (string, uint64) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Protocol")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(uint64)
@@ -245,11 +278,13 @@ func (m *MockBackend) Protocol() (string, uint64) {
 
 // Protocol indicates an expected call of Protocol
 func (mr *MockBackendMockRecorder) Protocol() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Protocol", reflect.TypeOf((*MockBackend)(nil).Protocol))
 }
 
 // Start mocks base method
 func (m *MockBackend) Start(ctx context.Context, chain consensus.ChainReader, currentBlock func() *types.Block, hasBadBlock func(common.Hash) bool) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", ctx, chain, currentBlock, hasBadBlock)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -257,11 +292,13 @@ func (m *MockBackend) Start(ctx context.Context, chain consensus.ChainReader, cu
 
 // Start indicates an expected call of Start
 func (mr *MockBackendMockRecorder) Start(ctx, chain, currentBlock, hasBadBlock interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockBackend)(nil).Start), ctx, chain, currentBlock, hasBadBlock)
 }
 
 // Address mocks base method
 func (m *MockBackend) Address() common.Address {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Address")
 	ret0, _ := ret[0].(common.Address)
 	return ret0
@@ -269,11 +306,13 @@ func (m *MockBackend) Address() common.Address {
 
 // Address indicates an expected call of Address
 func (mr *MockBackendMockRecorder) Address() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockBackend)(nil).Address))
 }
 
 // Validators mocks base method
 func (m *MockBackend) Validators(number uint64) validator.Set {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validators", number)
 	ret0, _ := ret[0].(validator.Set)
 	return ret0
@@ -281,11 +320,13 @@ func (m *MockBackend) Validators(number uint64) validator.Set {
 
 // Validators indicates an expected call of Validators
 func (mr *MockBackendMockRecorder) Validators(number interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validators", reflect.TypeOf((*MockBackend)(nil).Validators), number)
 }
 
 // Subscribe mocks base method
 func (m *MockBackend) Subscribe(types ...interface{}) *event.TypeMuxSubscription {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range types {
 		varargs = append(varargs, a)
@@ -297,21 +338,25 @@ func (m *MockBackend) Subscribe(types ...interface{}) *event.TypeMuxSubscription
 
 // Subscribe indicates an expected call of Subscribe
 func (mr *MockBackendMockRecorder) Subscribe(types ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockBackend)(nil).Subscribe), types...)
 }
 
 // Post mocks base method
 func (m *MockBackend) Post(ev interface{}) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Post", ev)
 }
 
 // Post indicates an expected call of Post
 func (mr *MockBackendMockRecorder) Post(ev interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MockBackend)(nil).Post), ev)
 }
 
 // Broadcast mocks base method
 func (m *MockBackend) Broadcast(ctx context.Context, valSet validator.Set, payload []byte) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Broadcast", ctx, valSet, payload)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -319,21 +364,25 @@ func (m *MockBackend) Broadcast(ctx context.Context, valSet validator.Set, paylo
 
 // Broadcast indicates an expected call of Broadcast
 func (mr *MockBackendMockRecorder) Broadcast(ctx, valSet, payload interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Broadcast", reflect.TypeOf((*MockBackend)(nil).Broadcast), ctx, valSet, payload)
 }
 
 // Gossip mocks base method
 func (m *MockBackend) Gossip(ctx context.Context, valSet validator.Set, payload []byte) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Gossip", ctx, valSet, payload)
 }
 
 // Gossip indicates an expected call of Gossip
 func (mr *MockBackendMockRecorder) Gossip(ctx, valSet, payload interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gossip", reflect.TypeOf((*MockBackend)(nil).Gossip), ctx, valSet, payload)
 }
 
 // Commit mocks base method
 func (m *MockBackend) Commit(proposalBlock types.Block, seals [][]byte) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Commit", proposalBlock, seals)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -341,11 +390,13 @@ func (m *MockBackend) Commit(proposalBlock types.Block, seals [][]byte) error {
 
 // Commit indicates an expected call of Commit
 func (mr *MockBackendMockRecorder) Commit(proposalBlock, seals interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockBackend)(nil).Commit), proposalBlock, seals)
 }
 
 // VerifyProposal mocks base method
 func (m *MockBackend) VerifyProposal(arg0 types.Block) (time.Duration, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyProposal", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	ret1, _ := ret[1].(error)
@@ -354,11 +405,13 @@ func (m *MockBackend) VerifyProposal(arg0 types.Block) (time.Duration, error) {
 
 // VerifyProposal indicates an expected call of VerifyProposal
 func (mr *MockBackendMockRecorder) VerifyProposal(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyProposal", reflect.TypeOf((*MockBackend)(nil).VerifyProposal), arg0)
 }
 
 // Sign mocks base method
 func (m *MockBackend) Sign(arg0 []byte) ([]byte, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sign", arg0)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -367,11 +420,13 @@ func (m *MockBackend) Sign(arg0 []byte) ([]byte, error) {
 
 // Sign indicates an expected call of Sign
 func (mr *MockBackendMockRecorder) Sign(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockBackend)(nil).Sign), arg0)
 }
 
 // CheckSignature mocks base method
 func (m *MockBackend) CheckSignature(data []byte, addr common.Address, sig []byte) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckSignature", data, addr, sig)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -379,11 +434,13 @@ func (m *MockBackend) CheckSignature(data []byte, addr common.Address, sig []byt
 
 // CheckSignature indicates an expected call of CheckSignature
 func (mr *MockBackendMockRecorder) CheckSignature(data, addr, sig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckSignature", reflect.TypeOf((*MockBackend)(nil).CheckSignature), data, addr, sig)
 }
 
 // LastCommittedProposal mocks base method
 func (m *MockBackend) LastCommittedProposal() (*types.Block, common.Address) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LastCommittedProposal")
 	ret0, _ := ret[0].(*types.Block)
 	ret1, _ := ret[1].(common.Address)
@@ -392,11 +449,13 @@ func (m *MockBackend) LastCommittedProposal() (*types.Block, common.Address) {
 
 // LastCommittedProposal indicates an expected call of LastCommittedProposal
 func (mr *MockBackendMockRecorder) LastCommittedProposal() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastCommittedProposal", reflect.TypeOf((*MockBackend)(nil).LastCommittedProposal))
 }
 
 // GetProposer mocks base method
 func (m *MockBackend) GetProposer(number uint64) common.Address {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProposer", number)
 	ret0, _ := ret[0].(common.Address)
 	return ret0
@@ -404,11 +463,13 @@ func (m *MockBackend) GetProposer(number uint64) common.Address {
 
 // GetProposer indicates an expected call of GetProposer
 func (mr *MockBackendMockRecorder) GetProposer(number interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProposer", reflect.TypeOf((*MockBackend)(nil).GetProposer), number)
 }
 
 // HasBadProposal mocks base method
 func (m *MockBackend) HasBadProposal(hash common.Hash) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasBadProposal", hash)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -416,41 +477,73 @@ func (m *MockBackend) HasBadProposal(hash common.Hash) bool {
 
 // HasBadProposal indicates an expected call of HasBadProposal
 func (mr *MockBackendMockRecorder) HasBadProposal(hash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBadProposal", reflect.TypeOf((*MockBackend)(nil).HasBadProposal), hash)
 }
 
 // SetProposedBlockHash mocks base method
 func (m *MockBackend) SetProposedBlockHash(hash common.Hash) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetProposedBlockHash", hash)
 }
 
 // SetProposedBlockHash indicates an expected call of SetProposedBlockHash
 func (mr *MockBackendMockRecorder) SetProposedBlockHash(hash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProposedBlockHash", reflect.TypeOf((*MockBackend)(nil).SetProposedBlockHash), hash)
 }
 
 // SyncPeer mocks base method
 func (m *MockBackend) SyncPeer(address common.Address, messages []*Message) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SyncPeer", address, messages)
 }
 
 // SyncPeer indicates an expected call of SyncPeer
 func (mr *MockBackendMockRecorder) SyncPeer(address, messages interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncPeer", reflect.TypeOf((*MockBackend)(nil).SyncPeer), address, messages)
 }
 
 // ResetPeerCache mocks base method
 func (m *MockBackend) ResetPeerCache(address common.Address) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ResetPeerCache", address)
 }
 
 // ResetPeerCache indicates an expected call of ResetPeerCache
 func (mr *MockBackendMockRecorder) ResetPeerCache(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetPeerCache", reflect.TypeOf((*MockBackend)(nil).ResetPeerCache), address)
+}
+
+// AskSync mocks base method
+func (m *MockBackend) AskSync(set validator.Set) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AskSync", set)
+}
+
+// AskSync indicates an expected call of AskSync
+func (mr *MockBackendMockRecorder) AskSync(set interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskSync", reflect.TypeOf((*MockBackend)(nil).AskSync), set)
+}
+
+// HandleUnhandledMsgs mocks base method
+func (m *MockBackend) HandleUnhandledMsgs(ctx context.Context) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "HandleUnhandledMsgs", ctx)
+}
+
+// HandleUnhandledMsgs indicates an expected call of HandleUnhandledMsgs
+func (mr *MockBackendMockRecorder) HandleUnhandledMsgs(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleUnhandledMsgs", reflect.TypeOf((*MockBackend)(nil).HandleUnhandledMsgs), ctx)
 }
 
 // GetContractAddress mocks base method
 func (m *MockBackend) GetContractAddress() common.Address {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContractAddress")
 	ret0, _ := ret[0].(common.Address)
 	return ret0
@@ -458,11 +551,13 @@ func (m *MockBackend) GetContractAddress() common.Address {
 
 // GetContractAddress indicates an expected call of GetContractAddress
 func (mr *MockBackendMockRecorder) GetContractAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContractAddress", reflect.TypeOf((*MockBackend)(nil).GetContractAddress))
 }
 
 // GetContractABI mocks base method
 func (m *MockBackend) GetContractABI() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContractABI")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -470,11 +565,13 @@ func (m *MockBackend) GetContractABI() string {
 
 // GetContractABI indicates an expected call of GetContractABI
 func (mr *MockBackendMockRecorder) GetContractABI() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContractABI", reflect.TypeOf((*MockBackend)(nil).GetContractABI))
 }
 
 // WhiteList mocks base method
 func (m *MockBackend) WhiteList() []string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WhiteList")
 	ret0, _ := ret[0].([]string)
 	return ret0
@@ -482,27 +579,6 @@ func (m *MockBackend) WhiteList() []string {
 
 // WhiteList indicates an expected call of WhiteList
 func (mr *MockBackendMockRecorder) WhiteList() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WhiteList", reflect.TypeOf((*MockBackend)(nil).WhiteList))
-}
-
-// AskSync mocks base method
-func (m *MockBackend) AskSync(set validator.Set) {
-	m.ctrl.Call(m, "AskSync", set)
-}
-
-// AskSync indicates an expected call of AskSync
-func (mr *MockBackendMockRecorder) AskSync(set interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskSync", reflect.TypeOf((*MockBackend)(nil).AskSync), set)
-}
-
-// HandleUnhandledMsgs mocks base method
-func (m *MockBackend) HandleUnhandledMsgs() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "HandleUnhandledMsgs")
-}
-
-// HandleUnhandledMsgs indicates an expected call of HandleUnhandledMsgs
-func (mr *MockBackendMockRecorder) HandleUnhandledMsgs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleUnhandledMsgs", reflect.TypeOf((*MockBackend)(nil).HandleUnhandledMsgs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WhiteList", reflect.TypeOf((*MockBackend)(nil).WhiteList))
 }

--- a/consensus/tendermint/core/backlog.go
+++ b/consensus/tendermint/core/backlog.go
@@ -42,7 +42,8 @@ type backlogEvent struct {
 // return errInvalidMessage if the message is invalid
 // return errFutureHeightMessage if the message view is larger than currentRoundState view
 // return errOldHeightMessage if the message view is smaller than currentRoundState view
-func (c *core) checkMessage(round *big.Int, height *big.Int) error {
+// return errFutureStepMessage if we are at the same view but at the propose step and it's a voting message.
+func (c *core) checkMessage(round *big.Int, height *big.Int, step Step) error {
 	if height == nil || round == nil {
 		return errInvalidMessage
 	}
@@ -55,6 +56,8 @@ func (c *core) checkMessage(round *big.Int, height *big.Int) error {
 		return errFutureRoundMessage
 	} else if round.Cmp(c.currentRoundState.Round()) < 0 {
 		return errOldRoundMessage
+	} else if c.currentRoundState.step == propose && step > propose {
+		return errFutureStepMessage
 	}
 
 	return nil
@@ -134,10 +137,10 @@ func (c *core) processBacklog() {
 				continue
 			}
 			// Push back if it's a future message
-			err := c.checkMessage(round, height)
+			err := c.checkMessage(round, height, Step(msg.Code))
 			if err != nil {
-				if err == errFutureHeightMessage || err == errFutureRoundMessage {
-					logger.Debug("Stop processing backlog", "msg", msg)
+				if err == errFutureHeightMessage || err == errFutureRoundMessage || err == errFutureStepMessage {
+					logger.Debug("Stop processing backlog", "msg", msg, "err", err)
 					backlog.Push(msg, prio)
 					isFuture = true
 					break

--- a/consensus/tendermint/core/backlog_test.go
+++ b/consensus/tendermint/core/backlog_test.go
@@ -21,7 +21,7 @@ func TestCheckMessage(t *testing.T) {
 			currentRoundState: NewRoundState(big.NewInt(1), big.NewInt(2)),
 		}
 
-		err := c.checkMessage(big.NewInt(1), big.NewInt(2))
+		err := c.checkMessage(big.NewInt(1), big.NewInt(2), propose)
 		if err != nil {
 			t.Fatalf("have %v, want nil", err)
 		}
@@ -30,7 +30,7 @@ func TestCheckMessage(t *testing.T) {
 	t.Run("given nil round, error returned", func(t *testing.T) {
 		c := &core{}
 
-		err := c.checkMessage(nil, big.NewInt(2))
+		err := c.checkMessage(nil, big.NewInt(2), propose)
 		if err != errInvalidMessage {
 			t.Fatalf("have %v, want %v", err, errInvalidMessage)
 		}
@@ -41,7 +41,7 @@ func TestCheckMessage(t *testing.T) {
 			currentRoundState: NewRoundState(big.NewInt(2), big.NewInt(3)),
 		}
 
-		err := c.checkMessage(big.NewInt(2), big.NewInt(4))
+		err := c.checkMessage(big.NewInt(2), big.NewInt(4), propose)
 		if err != errFutureHeightMessage {
 			t.Fatalf("have %v, want %v", err, errFutureHeightMessage)
 		}
@@ -52,7 +52,7 @@ func TestCheckMessage(t *testing.T) {
 			currentRoundState: NewRoundState(big.NewInt(2), big.NewInt(3)),
 		}
 
-		err := c.checkMessage(big.NewInt(2), big.NewInt(2))
+		err := c.checkMessage(big.NewInt(2), big.NewInt(2), propose)
 		if err != errOldHeightMessage {
 			t.Fatalf("have %v, want %v", err, errOldHeightMessage)
 		}
@@ -63,7 +63,7 @@ func TestCheckMessage(t *testing.T) {
 			currentRoundState: NewRoundState(big.NewInt(2), big.NewInt(3)),
 		}
 
-		err := c.checkMessage(big.NewInt(3), big.NewInt(3))
+		err := c.checkMessage(big.NewInt(3), big.NewInt(3), propose)
 		if err != errFutureRoundMessage {
 			t.Fatalf("have %v, want %v", err, errFutureRoundMessage)
 		}
@@ -74,7 +74,7 @@ func TestCheckMessage(t *testing.T) {
 			currentRoundState: NewRoundState(big.NewInt(2), big.NewInt(2)),
 		}
 
-		err := c.checkMessage(big.NewInt(1), big.NewInt(2))
+		err := c.checkMessage(big.NewInt(1), big.NewInt(2), propose)
 		if err != errOldRoundMessage {
 			t.Fatalf("have %v, want %v", err, errOldRoundMessage)
 		}

--- a/consensus/tendermint/core/core.go
+++ b/consensus/tendermint/core/core.go
@@ -48,6 +48,9 @@ var (
 	errOldRoundMessage = errors.New("same height but old round message")
 	// errFutureRoundMessage message is returned when message is of the same Height but form a newer round
 	errFutureRoundMessage = errors.New("same height but future round message")
+	// errFutureStepMessage message is returned when it's a prevote or precommit message of the same Height same round
+	// while the current step is propose.
+	errFutureStepMessage = errors.New("same round but future step message")
 	// errInvalidMessage is returned when the message is malformed.
 	errInvalidMessage = errors.New("invalid message")
 	// errInvalidSenderOfCommittedSeal is returned when the committed seal is not from the sender of the message.

--- a/consensus/tendermint/core/core.go
+++ b/consensus/tendermint/core/core.go
@@ -92,6 +92,7 @@ func New(backend Backend, config *config.Config) *core {
 		currentHeightOldRoundsStates: make(map[int64]*roundState),
 		lockedRound:                  big.NewInt(-1),
 		validRound:                   big.NewInt(-1),
+		currentRoundState:            new(roundState),
 		proposeTimeout:               newTimeout(propose, logger),
 		prevoteTimeout:               newTimeout(prevote, logger),
 		precommitTimeout:             newTimeout(precommit, logger),
@@ -123,8 +124,7 @@ type core struct {
 	backlogs   map[validator.Validator]*prque.Prque
 	backlogsMu sync.Mutex
 
-	currentRoundStateMu sync.RWMutex
-	currentRoundState   *roundState
+	currentRoundState *roundState
 
 	// map[Height]UnminedBlock
 	pendingUnminedBlocks     map[uint64]*types.Block
@@ -163,9 +163,7 @@ func (c *core) GetCurrentHeightMessages() []*Message {
 		msgs[i] = state.GetMessages()
 		totalLen += len(msgs[i])
 	}
-	c.currentRoundStateMu.RLock()
 	msgs[len(msgs)-1] = c.currentRoundState.GetMessages()
-	c.currentRoundStateMu.RUnlock()
 
 	totalLen += len(msgs[len(msgs)-1])
 
@@ -334,9 +332,8 @@ func (c *core) setCore(r *big.Int, h *big.Int, lastProposer common.Address) {
 		c.currentHeightOldRoundsStates[r.Int64()-1] = c.currentRoundState
 		c.currentHeightOldRoundsStatesMu.Unlock()
 	}
-	c.currentRoundStateMu.Lock()
-	c.currentRoundState = NewRoundState(r, h)
-	c.currentRoundStateMu.Unlock()
+	c.currentRoundState.Update(r, h)
+
 	// Calculate new proposer
 	c.valSet.CalcProposer(lastProposer, r.Uint64())
 	c.sentProposal = false

--- a/consensus/tendermint/core/core_backend.go
+++ b/consensus/tendermint/core/core_backend.go
@@ -151,7 +151,7 @@ type Backend interface {
 
 	AskSync(set validator.Set)
 
-	HandleUnhandledMsgs()
+	HandleUnhandledMsgs(ctx context.Context)
 
 	GetContractAddress() common.Address
 

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -325,6 +325,9 @@ func (c *core) handleCheckedMsg(ctx context.Context, msg *Message, sender valida
 				logger.Debug("Received ceil(N/3) - 1 messages for higher round", "New round", msgRound)
 				c.startRound(ctx, big.NewInt(msgRound))
 			}
+		} else if err == errFutureStepMessage {
+			logger.Debug("Storing future step message in backlog")
+			c.storeBacklog(msg, sender)
 		}
 
 		return err

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -57,7 +57,7 @@ func (c *core) Start(ctx context.Context, chain consensus.ChainReader, currentBl
 	// set currentRoundState before starting go routines
 	lastCommittedProposalBlock, _ := c.backend.LastCommittedProposal()
 	height := new(big.Int).Add(lastCommittedProposalBlock.Number(), common.Big1)
-	c.currentRoundState = NewRoundState(big.NewInt(0), height)
+	c.currentRoundState.Update(big.NewInt(0), height)
 
 	//We need a separate go routine to keep c.latestPendingUnminedBlock up to date
 	go c.handleNewUnminedBlockEvent(ctx)
@@ -65,7 +65,7 @@ func (c *core) Start(ctx context.Context, chain consensus.ChainReader, currentBl
 	//We want to sequentially handle all the event which modify the current consensus state
 	go c.handleConsensusEvents(ctx)
 
-	go c.backend.HandleUnhandledMsgs()
+	go c.backend.HandleUnhandledMsgs(ctx)
 
 	return nil
 }
@@ -234,10 +234,9 @@ func (c *core) syncLoop(ctx context.Context) {
 		and to process sync queries events.
 	*/
 	timer := time.NewTimer(10 * time.Second)
-	c.currentRoundStateMu.RLock()
+
 	round := c.currentRoundState.Round()
 	height := c.currentRoundState.Height()
-	c.currentRoundStateMu.RUnlock()
 
 	// Ask for sync when the engine starts
 	c.backend.AskSync(c.valSet.Copy())
@@ -245,10 +244,9 @@ func (c *core) syncLoop(ctx context.Context) {
 	for {
 		select {
 		case <-timer.C:
-			c.currentRoundStateMu.RLock()
 			currentRound := c.currentRoundState.Round()
 			currentHeight := c.currentRoundState.Height()
-			c.currentRoundStateMu.RUnlock()
+
 			// we only ask for sync if the current view stayed the same for the past 10 seconds
 			if currentHeight.Cmp(height) == 0 && currentRound.Cmp(round) == 0 {
 				c.backend.AskSync(c.valSet.Copy())

--- a/consensus/tendermint/core/precommit.go
+++ b/consensus/tendermint/core/precommit.go
@@ -160,7 +160,14 @@ func (c *core) verifyPrecommitCommittedSeal(addressMsg common.Address, committed
 
 func (c *core) handleCommit(ctx context.Context) {
 	c.logger.Debug("Received a final committed proposal", "step", c.currentRoundState.Step())
-	c.startRound(ctx, common.Big0)
+	lastBlock, _ := c.backend.LastCommittedProposal()
+	height := new(big.Int).Add(lastBlock.Number(), common.Big1).Uint64()
+	if height == c.currentRoundState.Height().Uint64() {
+		c.logger.Debug("Discarding event as core is at the same height", "state_height", c.currentRoundState.Height().Uint64())
+	} else {
+		c.logger.Debug("Received proposal is ahead", "state_height", c.currentRoundState.Height().Uint64(), "block_height", height)
+		c.startRound(ctx, common.Big0)
+	}
 }
 
 func (c *core) logPrecommitMessageEvent(message string, precommit Vote, from, to string) {

--- a/consensus/tendermint/core/precommit.go
+++ b/consensus/tendermint/core/precommit.go
@@ -76,7 +76,7 @@ func (c *core) handlePrecommit(ctx context.Context, msg *Message) error {
 		return errFailedDecodePrecommit
 	}
 
-	if err := c.checkMessage(preCommit.Round, preCommit.Height); err != nil {
+	if err := c.checkMessage(preCommit.Round, preCommit.Height, precommit); err != nil {
 		// Store old precommits because if there is a quorum of precommits in the previous round we need to go to the next height
 		//if err == errOldRoundMessage {
 		//	// The roundstate must exist as every roundstate is added to c.currentHeightRoundsState at startRound

--- a/consensus/tendermint/core/precommit_test.go
+++ b/consensus/tendermint/core/precommit_test.go
@@ -227,7 +227,7 @@ func TestHandlePrecommit(t *testing.T) {
 			logger:            log.New("backend", "test", "id", 0),
 			valSet:            new(validatorSet),
 		}
-
+		c.setStep(precommit)
 		err = c.handlePrecommit(context.Background(), expectedMsg)
 		if err != secp256k1.ErrInvalidSignatureLen {
 			t.Fatalf("Expected %v, got %v", secp256k1.ErrInvalidSignatureLen, err)
@@ -250,7 +250,7 @@ func TestHandlePrecommit(t *testing.T) {
 
 		curRoundState := NewRoundState(big.NewInt(2), big.NewInt(3))
 		curRoundState.SetProposal(proposal, nil)
-
+		curRoundState.SetStep(precommit)
 		addr := getAddress()
 
 		var preCommit = Vote{
@@ -314,6 +314,7 @@ func TestHandlePrecommit(t *testing.T) {
 
 		curRoundState := NewRoundState(big.NewInt(2), big.NewInt(3))
 		curRoundState.SetProposal(proposal, nil)
+		curRoundState.SetStep(prevote)
 
 		addr := getAddress()
 
@@ -366,6 +367,7 @@ func TestHandlePrecommit(t *testing.T) {
 
 	t.Run("pre-commit given with no errors, pre-commit timeout triggered", func(t *testing.T) {
 		curRoundState := NewRoundState(big.NewInt(2), big.NewInt(3))
+		curRoundState.SetStep(precommit)
 		addr := getAddress()
 
 		var preCommit = Vote{
@@ -489,7 +491,7 @@ func TestHandleCommit(t *testing.T) {
 	addr := common.HexToAddress("0x0123456789")
 
 	backendMock := NewMockBackend(ctrl)
-	backendMock.EXPECT().LastCommittedProposal().Return(block, addr)
+	backendMock.EXPECT().LastCommittedProposal().MinTimes(1).Return(block, addr)
 
 	valSet := validator.NewMockSet(ctrl)
 	valSet.EXPECT().CalcProposer(addr, uint64(0))

--- a/consensus/tendermint/core/prevote.go
+++ b/consensus/tendermint/core/prevote.go
@@ -65,7 +65,7 @@ func (c *core) handlePrevote(ctx context.Context, msg *Message) error {
 		return errFailedDecodePrevote
 	}
 
-	if err = c.checkMessage(preVote.Round, preVote.Height); err != nil {
+	if err = c.checkMessage(preVote.Round, preVote.Height, prevote); err != nil {
 		// Store old round prevote messages for future rounds since it is required for validRound
 		if err == errOldRoundMessage {
 			// We only process old rounds while future rounds messages are pushed on to the backlog

--- a/consensus/tendermint/core/propose.go
+++ b/consensus/tendermint/core/propose.go
@@ -67,7 +67,7 @@ func (c *core) handleProposal(ctx context.Context, msg *Message) error {
 	}
 
 	// Ensure we have the same view with the Proposal message
-	if err := c.checkMessage(proposal.Round, proposal.Height); err != nil {
+	if err := c.checkMessage(proposal.Round, proposal.Height, propose); err != nil {
 		// We don't care about old proposals so they are ignored
 		return err
 	}

--- a/consensus/tendermint/core/roundstate.go
+++ b/consensus/tendermint/core/roundstate.go
@@ -33,7 +33,6 @@ func NewRoundState(r *big.Int, h *big.Int) *roundState {
 		proposal:   new(Proposal),
 		Prevotes:   newMessageSet(),
 		Precommits: newMessageSet(),
-		mu:         new(sync.RWMutex),
 	}
 }
 
@@ -47,7 +46,7 @@ type roundState struct {
 	proposalMsg *Message
 	Prevotes    messageSet
 	Precommits  messageSet
-	mu          *sync.RWMutex
+	mu          sync.RWMutex
 }
 
 func (s *roundState) Update(r *big.Int, h *big.Int) {
@@ -119,6 +118,13 @@ func (s *roundState) Step() Step {
 	defer s.mu.RUnlock()
 
 	return s.step
+}
+
+func (s *roundState) State() (*big.Int, *big.Int, uint64) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.height, s.round, uint64(s.step)
 }
 
 func (s *roundState) GetCurrentProposalHash() common.Hash {

--- a/consensus/tendermint/core/unmined_block.go
+++ b/consensus/tendermint/core/unmined_block.go
@@ -42,8 +42,6 @@ func (c *core) storeUnminedBlockMsg(unminedBlock *types.Block) {
 func (c *core) updatePendingUnminedBlocks(unminedBlock *types.Block) {
 	c.pendingUnminedBlocksMu.Lock()
 	defer c.pendingUnminedBlocksMu.Unlock()
-	c.currentRoundStateMu.RLock()
-	defer c.currentRoundStateMu.RUnlock()
 
 	// Get all heights from c.pendingUnminedBlocks and remove previous height unmined blocks
 	var heights = make([]uint64, 0)
@@ -83,9 +81,6 @@ func (c *core) getUnminedBlock() *types.Block {
 // return errFutureHeightMessage if the height of proposal is larger than currentRoundState height
 // return errOldHeightMessage if the height of proposal is smaller than currentRoundState height
 func (c *core) checkUnminedBlockMsg(unminedBlock *types.Block) error {
-	c.currentRoundStateMu.RLock()
-	defer c.currentRoundStateMu.RUnlock()
-
 	if unminedBlock == nil {
 		return errInvalidMessage
 	}
@@ -101,15 +96,15 @@ func (c *core) checkUnminedBlockMsg(unminedBlock *types.Block) error {
 }
 
 func (c *core) logNewUnminedBlockEvent(ub *types.Block) {
-	c.currentRoundStateMu.RLock()
-	defer c.currentRoundStateMu.RUnlock()
+	h, r, s := c.currentRoundState.State()
+
 	c.logger.Debug("NewUnminedBlockEvent: Received",
 		"from", c.address.String(),
 		"type", "New Unmined Block",
 		"hash", ub.Hash(),
-		"currentHeight", c.currentRoundState.Height(),
-		"currentRound", c.currentRoundState.Round(),
-		"currentStep", c.currentRoundState.Step(),
+		"currentHeight", h,
+		"currentRound", r,
+		"currentStep", s,
 		"currentProposer", c.isProposer(),
 		"msgHeight", ub.Header().Number.Uint64(),
 		"isNilMsg", ub.Hash() == common.Hash{},

--- a/consensus/tendermint/validator/validator_mock.go
+++ b/consensus/tendermint/validator/validator_mock.go
@@ -36,6 +36,7 @@ func (m *MockValidator) EXPECT() *MockValidatorMockRecorder {
 
 // Address mocks base method
 func (m *MockValidator) Address() common.Address {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Address")
 	ret0, _ := ret[0].(common.Address)
 	return ret0
@@ -43,11 +44,13 @@ func (m *MockValidator) Address() common.Address {
 
 // Address indicates an expected call of Address
 func (mr *MockValidatorMockRecorder) Address() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockValidator)(nil).Address))
 }
 
 // String mocks base method
 func (m *MockValidator) String() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -55,6 +58,7 @@ func (m *MockValidator) String() string {
 
 // String indicates an expected call of String
 func (mr *MockValidatorMockRecorder) String() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockValidator)(nil).String))
 }
 
@@ -83,16 +87,19 @@ func (m *MockSet) EXPECT() *MockSetMockRecorder {
 
 // CalcProposer mocks base method
 func (m *MockSet) CalcProposer(lastProposer common.Address, round uint64) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CalcProposer", lastProposer, round)
 }
 
 // CalcProposer indicates an expected call of CalcProposer
 func (mr *MockSetMockRecorder) CalcProposer(lastProposer, round interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcProposer", reflect.TypeOf((*MockSet)(nil).CalcProposer), lastProposer, round)
 }
 
 // Size mocks base method
 func (m *MockSet) Size() int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Size")
 	ret0, _ := ret[0].(int)
 	return ret0
@@ -100,11 +107,13 @@ func (m *MockSet) Size() int {
 
 // Size indicates an expected call of Size
 func (mr *MockSetMockRecorder) Size() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockSet)(nil).Size))
 }
 
 // List mocks base method
 func (m *MockSet) List() []Validator {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List")
 	ret0, _ := ret[0].([]Validator)
 	return ret0
@@ -112,11 +121,13 @@ func (m *MockSet) List() []Validator {
 
 // List indicates an expected call of List
 func (mr *MockSetMockRecorder) List() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockSet)(nil).List))
 }
 
 // GetByIndex mocks base method
 func (m *MockSet) GetByIndex(i uint64) Validator {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetByIndex", i)
 	ret0, _ := ret[0].(Validator)
 	return ret0
@@ -124,11 +135,13 @@ func (m *MockSet) GetByIndex(i uint64) Validator {
 
 // GetByIndex indicates an expected call of GetByIndex
 func (mr *MockSetMockRecorder) GetByIndex(i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByIndex", reflect.TypeOf((*MockSet)(nil).GetByIndex), i)
 }
 
 // GetByAddress mocks base method
 func (m *MockSet) GetByAddress(addr common.Address) (int, Validator) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetByAddress", addr)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(Validator)
@@ -137,11 +150,13 @@ func (m *MockSet) GetByAddress(addr common.Address) (int, Validator) {
 
 // GetByAddress indicates an expected call of GetByAddress
 func (mr *MockSetMockRecorder) GetByAddress(addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByAddress", reflect.TypeOf((*MockSet)(nil).GetByAddress), addr)
 }
 
 // GetProposer mocks base method
 func (m *MockSet) GetProposer() Validator {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProposer")
 	ret0, _ := ret[0].(Validator)
 	return ret0
@@ -149,11 +164,13 @@ func (m *MockSet) GetProposer() Validator {
 
 // GetProposer indicates an expected call of GetProposer
 func (mr *MockSetMockRecorder) GetProposer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProposer", reflect.TypeOf((*MockSet)(nil).GetProposer))
 }
 
 // IsProposer mocks base method
 func (m *MockSet) IsProposer(address common.Address) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsProposer", address)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -161,11 +178,13 @@ func (m *MockSet) IsProposer(address common.Address) bool {
 
 // IsProposer indicates an expected call of IsProposer
 func (mr *MockSetMockRecorder) IsProposer(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsProposer", reflect.TypeOf((*MockSet)(nil).IsProposer), address)
 }
 
 // AddValidator mocks base method
 func (m *MockSet) AddValidator(address common.Address) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddValidator", address)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -173,11 +192,13 @@ func (m *MockSet) AddValidator(address common.Address) bool {
 
 // AddValidator indicates an expected call of AddValidator
 func (mr *MockSetMockRecorder) AddValidator(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddValidator", reflect.TypeOf((*MockSet)(nil).AddValidator), address)
 }
 
 // RemoveValidator mocks base method
 func (m *MockSet) RemoveValidator(address common.Address) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveValidator", address)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -185,11 +206,13 @@ func (m *MockSet) RemoveValidator(address common.Address) bool {
 
 // RemoveValidator indicates an expected call of RemoveValidator
 func (mr *MockSetMockRecorder) RemoveValidator(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveValidator", reflect.TypeOf((*MockSet)(nil).RemoveValidator), address)
 }
 
 // Copy mocks base method
 func (m *MockSet) Copy() Set {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Copy")
 	ret0, _ := ret[0].(Set)
 	return ret0
@@ -197,11 +220,13 @@ func (m *MockSet) Copy() Set {
 
 // Copy indicates an expected call of Copy
 func (mr *MockSetMockRecorder) Copy() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Copy", reflect.TypeOf((*MockSet)(nil).Copy))
 }
 
 // F mocks base method
 func (m *MockSet) F() int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "F")
 	ret0, _ := ret[0].(int)
 	return ret0
@@ -209,6 +234,7 @@ func (m *MockSet) F() int {
 
 // F indicates an expected call of F
 func (mr *MockSetMockRecorder) F() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "F", reflect.TypeOf((*MockSet)(nil).F))
 }
 
@@ -228,6 +254,7 @@ func (mr *MockSetMockRecorder) Quorum() *gomock.Call {
 
 // Policy mocks base method
 func (m *MockSet) Policy() config.ProposerPolicy {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Policy")
 	ret0, _ := ret[0].(config.ProposerPolicy)
 	return ret0
@@ -235,5 +262,6 @@ func (m *MockSet) Policy() config.ProposerPolicy {
 
 // Policy indicates an expected call of Policy
 func (mr *MockSetMockRecorder) Policy() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Policy", reflect.TypeOf((*MockSet)(nil).Policy))
 }

--- a/consensus/test/tendermint_test.go
+++ b/consensus/test/tendermint_test.go
@@ -1040,7 +1040,7 @@ func runTest(t *testing.T, test *testCase) {
 		t.SkipNow()
 	}
 
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlDebug, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlError, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
 	_, err := fdlimit.Raise(512 * uint64(test.numPeers))
 	if err != nil {
 		t.Log("can't rise file description limit. errors are possible")

--- a/consensus/test/tendermint_test.go
+++ b/consensus/test/tendermint_test.go
@@ -470,7 +470,7 @@ func TestTendermintStartStopSingleNode(t *testing.T) {
 		{
 			name:      "one node stops for 5 seconds",
 			numPeers:  5,
-			numBlocks: 10,
+			numBlocks: 20,
 			txPerPeer: 1,
 			beforeHooks: map[int]hook{
 				4: hookStopNode(4, 5),
@@ -483,7 +483,7 @@ func TestTendermintStartStopSingleNode(t *testing.T) {
 		{
 			name:      "one node stops for 10 seconds",
 			numPeers:  5,
-			numBlocks: 10,
+			numBlocks: 20,
 			txPerPeer: 1,
 			beforeHooks: map[int]hook{
 				4: hookStopNode(4, 5),
@@ -496,7 +496,7 @@ func TestTendermintStartStopSingleNode(t *testing.T) {
 		{
 			name:      "one node stops for 20 seconds",
 			numPeers:  5,
-			numBlocks: 20,
+			numBlocks: 30,
 			txPerPeer: 1,
 			beforeHooks: map[int]hook{
 				4: hookStopNode(4, 5),

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -958,6 +958,9 @@ type numberHash struct {
 func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain []types.Receipts, ancientLimit uint64) (int, error) {
 	// We don't require the chainMu here since we want to maximize the
 	// concurrency of header insertion and receipt insertion.
+	if atomic.LoadInt32(&bc.procInterrupt) == 1 {
+		return 0, nil
+	}
 	bc.wg.Add(1)
 	defer bc.wg.Done()
 
@@ -2122,6 +2125,9 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (i
 	bc.chainmu.Lock()
 	defer bc.chainmu.Unlock()
 
+	if atomic.LoadInt32(&bc.procInterrupt) == 1 {
+		return 0, nil
+	}
 	bc.wg.Add(1)
 	defer bc.wg.Done()
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -20,6 +20,7 @@ package miner
 import (
 	"fmt"
 	"math/big"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -58,6 +59,7 @@ type Miner struct {
 	mux      *event.TypeMux
 	worker   *worker
 	coinbase common.Address
+	coinbaseMu sync.RWMutex
 	eth      Backend
 	engine   consensus.Engine
 	exitCh   chan struct{}
@@ -84,8 +86,8 @@ func New(eth Backend, config *Config, chainConfig *params.ChainConfig, mux *even
 // It's entered once and as soon as `Done` or `Failed` has been broadcasted the events are unregistered and
 // the loop is exited. This to prevent a major security vuln where external parties can DOS you with blocks
 // and halt your mining operation for as long as the DOS continues.
-func (self *Miner) update() {
-	events := self.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
+func (m *Miner) update() {
+	events := m.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
 	defer events.Unsubscribe()
 
 	for {
@@ -96,78 +98,78 @@ func (self *Miner) update() {
 			}
 			switch ev.Data.(type) {
 			case downloader.StartEvent:
-				atomic.StoreInt32(&self.canStart, 0)
-				if self.Mining() {
-					self.Stop()
-					atomic.StoreInt32(&self.shouldStart, 1)
+				atomic.StoreInt32(&m.canStart, 0)
+				if m.Mining() {
+					m.Stop()
+					atomic.StoreInt32(&m.shouldStart, 1)
 					log.Info("Mining aborted due to sync")
 				}
 			case downloader.DoneEvent, downloader.FailedEvent:
-				shouldStart := atomic.LoadInt32(&self.shouldStart) == 1
+				shouldStart := atomic.LoadInt32(&m.shouldStart) == 1
 
-				atomic.StoreInt32(&self.canStart, 1)
-				atomic.StoreInt32(&self.shouldStart, 0)
+				atomic.StoreInt32(&m.canStart, 1)
+				atomic.StoreInt32(&m.shouldStart, 0)
 				if shouldStart {
-					self.Start(self.coinbase)
+					m.Start(m.Coinbase())
 				}
 				// stop immediately and ignore all further pending events
 				return
 			}
-		case <-self.exitCh:
+		case <-m.exitCh:
 			return
 		}
 	}
 }
 
-func (self *Miner) Start(coinbase common.Address) {
-	atomic.StoreInt32(&self.shouldStart, 1)
-	self.SetEtherbase(coinbase)
+func (m *Miner) Start(coinbase common.Address) {
+	atomic.StoreInt32(&m.shouldStart, 1)
+	m.SetEtherbase(coinbase)
 
-	if atomic.LoadInt32(&self.canStart) == 0 {
+	if atomic.LoadInt32(&m.canStart) == 0 {
 		log.Info("Network syncing, will start miner afterwards")
 		return
 	}
-	self.worker.start()
+	m.worker.start()
 }
 
-func (self *Miner) Stop() {
-	self.worker.stop()
-	atomic.StoreInt32(&self.shouldStart, 0)
+func (m *Miner) Stop() {
+	m.worker.stop()
+	atomic.StoreInt32(&m.shouldStart, 0)
 }
 
-func (self *Miner) Close() {
-	self.worker.stop()
-	self.worker.close()
-	close(self.exitCh)
+func (m *Miner) Close() {
+	m.worker.stop()
+	m.worker.close()
+	close(m.exitCh)
 }
 
-func (self *Miner) Mining() bool {
-	return self.worker.isRunning()
+func (m *Miner) Mining() bool {
+	return m.worker.isRunning()
 }
 
-func (self *Miner) HashRate() uint64 {
-	if pow, ok := self.engine.(consensus.PoW); ok {
+func (m *Miner) HashRate() uint64 {
+	if pow, ok := m.engine.(consensus.PoW); ok {
 		return uint64(pow.Hashrate())
 	}
 	return 0
 }
 
-func (self *Miner) SetExtra(extra []byte) error {
+func (m *Miner) SetExtra(extra []byte) error {
 	if uint64(len(extra)) > params.MaximumExtraDataSize {
 		return fmt.Errorf("Extra exceeds max length. %d > %v", len(extra), params.MaximumExtraDataSize)
 	}
-	self.worker.setExtra(extra)
+	m.worker.setExtra(extra)
 	return nil
 }
 
 // SetRecommitInterval sets the interval for sealing work resubmitting.
-func (self *Miner) SetRecommitInterval(interval time.Duration) {
-	self.worker.setRecommitInterval(interval)
+func (m *Miner) SetRecommitInterval(interval time.Duration) {
+	m.worker.setRecommitInterval(interval)
 }
 
 // Pending returns the currently pending block and associated state.
-func (self *Miner) Pending() (*types.Block, *state.StateDB) {
-	return self.worker.pending()
+func (m *Miner) Pending() (*types.Block, *state.StateDB) {
+	return m.worker.pending()
 }
 
 // PendingBlock returns the currently pending block.
@@ -175,11 +177,23 @@ func (self *Miner) Pending() (*types.Block, *state.StateDB) {
 // Note, to access both the pending block and the pending state
 // simultaneously, please use Pending(), as the pending state can
 // change between multiple method calls
-func (self *Miner) PendingBlock() *types.Block {
-	return self.worker.pendingBlock()
+func (m *Miner) PendingBlock() *types.Block {
+	return m.worker.pendingBlock()
 }
 
-func (self *Miner) SetEtherbase(addr common.Address) {
-	self.coinbase = addr
-	self.worker.setEtherbase(addr)
+func (m *Miner) SetEtherbase(addr common.Address) {
+	m.SetCoinbase(addr)
+	m.worker.setEtherbase(addr)
+}
+
+func (m *Miner) Coinbase() common.Address {
+	m.coinbaseMu.RLock()
+	defer m.coinbaseMu.RUnlock()
+	return m.coinbase
+}
+
+func (m *Miner) SetCoinbase(addr common.Address) {
+	m.coinbaseMu.Lock()
+	m.coinbase = addr
+	m.coinbaseMu.Unlock()
 }


### PR DESCRIPTION
- Adding support for TC7 test ( this change slightly how e2e tests are being performed).
- Solving issue with io.reader msg.payload not being properly saved by the handler due to discarding.
- Add new backlog error for future step messages, as prevote and precommit messages canot be properly processed while currently being on propose step.
