### PR TITLE
Fix resolver

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,10 +23,10 @@ jobs:
     needs: bootstrap-checkout
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
         id: go
 
       - name: Set GOPATH
@@ -51,10 +51,10 @@ jobs:
     needs: bootstrap-checkout
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
         id: go
 
       - name: Cache code
@@ -79,10 +79,10 @@ jobs:
     needs: bootstrap-checkout
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
         id: go
 
       - name: Set GOPATH
@@ -121,10 +121,10 @@ jobs:
     needs: bootstrap-checkout
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
         id: go
 
       - name: Set GOPATH
@@ -153,10 +153,10 @@ jobs:
     needs: bootstrap-checkout
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
         id: go
 
       - name: Cache code
@@ -216,10 +216,10 @@ jobs:
     name: Tendermint ${{ matrix.e2e }} test
 
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
         id: go
 
       - name: Cache code
@@ -240,10 +240,10 @@ jobs:
     env:
       GORACE: "history_size=7"
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
         id: go
 
       - name: Cache code

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,6 +43,10 @@ jobs:
           path: /home/runner/work/autonity/autonity/
           key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-aut-${{ env.cache-name }}-
+      - uses: actions/checkout@v2
+        if: steps.cache-autonity-code.outputs.cache-hit != 'true'
+        with:
+          clean: 'false'
 
       - name: unit tests
         run: go test -p 1 -timeout 30m -short $(go list ./... | grep -v /consensus/tendermint)
@@ -65,6 +69,10 @@ jobs:
           path: /home/runner/work/autonity/autonity/
           key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-aut-${{ env.cache-name }}-
+      - uses: actions/checkout@v2
+        if: steps.cache-autonity-code.outputs.cache-hit != 'true'
+        with:
+          clean: 'false'
 
       - name: tendermint_tests
         run: go test -v ./consensus/tendermint/... -timeout 30m -cover -covermode=atomic -test.coverprofile=coverage_tendermint.out
@@ -99,6 +107,10 @@ jobs:
           path: /home/runner/work/autonity/autonity/
           key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-aut-${{ env.cache-name }}-
+      - uses: actions/checkout@v2
+        if: steps.cache-autonity-code.outputs.cache-hit != 'true'
+        with:
+          clean: 'false'
 
       - name: Cache git modules
         uses: actions/cache@v1
@@ -109,7 +121,6 @@ jobs:
           path: /home/runner/work/autonity/autonity/tests/testdata
           key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ hashFiles('**/.gitmodules') }}
           restore-keys: ${{ runner.os }}-aut-${{ env.cache-name }}-
-
       - name: conformance tests
         if: steps.cache-git-modules.outputs.cache-hit != 'true'
         run: git submodule update --init --recursive
@@ -142,6 +153,10 @@ jobs:
           path: /home/runner/work/autonity/autonity/
           key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-aut-${{ env.cache-name }}-
+      - uses: actions/checkout@v2
+        if: steps.cache-autonity-code.outputs.cache-hit != 'true'
+        with:
+          clean: 'false'
 
       - name: Build
         run: make autonity
@@ -167,6 +182,10 @@ jobs:
           path: /home/runner/work/autonity/autonity/
           key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-aut-${{ env.cache-name }}-
+      - uses: actions/checkout@v2
+        if: steps.cache-autonity-code.outputs.cache-hit != 'true'
+        with:
+          clean: 'false'
 
       - name: Linters
         run: |
@@ -230,6 +249,10 @@ jobs:
           path: /home/runner/work/autonity/autonity/
           key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-aut-${{ env.cache-name }}-
+      - uses: actions/checkout@v2
+        if: steps.cache-autonity-code.outputs.cache-hit != 'true'
+        with:
+          clean: 'false'
 
       - name: Test
         run: go test ./consensus/test/... -v -run='${{ matrix.e2e }}' -timeout 40m
@@ -255,6 +278,10 @@ jobs:
           key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-aut-${{ env.cache-name }}-
+      - uses: actions/checkout@v2
+        if: steps.cache-autonity-code.outputs.cache-hit != 'true'
+        with:
+          clean: 'false'
 
       - name: unit
         run: go test -race -v ./consensus/tendermint/... -timeout 30m
@@ -273,7 +300,20 @@ jobs:
         run: npm install -g ganache-cli
       - name: run ganache
         run: ganache-cli --gasLimit=0x1fffffffffffff --allowUnlimitedContractSize -e 1000000000 &
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+
+      - name: Cache code
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-autonity-code
+        with:
+          path: /home/runner/work/autonity/autonity/
+          key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-aut-${{ env.cache-name }}-
+      - uses: actions/checkout@v2
+        if: steps.cache-autonity-code.outputs.cache-hit != 'true'
+        with:
+          clean: 'false'
+
       - name: test contract
         run: make test-contracts

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.13
         id: go
 
       - name: Set GOPATH
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.13
         id: go
 
       - name: Cache code
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.13
         id: go
 
       - name: Set GOPATH
@@ -124,7 +124,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.13
         id: go
 
       - name: Set GOPATH
@@ -156,7 +156,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.13
         id: go
 
       - name: Cache code
@@ -219,7 +219,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.13
         id: go
 
       - name: Cache code
@@ -243,7 +243,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.13
         id: go
 
       - name: Cache code

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -208,7 +208,9 @@ jobs:
               TestTendermintAddConnectionToTopologySuccess,
               TestTendermintAddValidatorsToTopologySuccess,
               TestTendermintAddParticipantsToTopologySuccess,
-              TestTendermintAddStakeholdersToTopologySuccess
+              TestTendermintAddStakeholdersToTopologySuccess,
+              TestAddStakeholderWithCorruptedEnodeToList,
+              TestAddIncorrectStakeholdersToList
         ]
 
     name: Tendermint ${{ matrix.e2e }} test

--- a/consensus/test/autonity_contract_test.go
+++ b/consensus/test/autonity_contract_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/clearmatics/autonity/common/keygenerator"
 	"github.com/clearmatics/autonity/common/math"
 	"github.com/clearmatics/autonity/log"
+	"github.com/clearmatics/autonity/p2p/enode"
 	"math/big"
+	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -335,6 +337,159 @@ func TestRemoveFromValidatorsList(t *testing.T) {
 			testCase.removedPeers[validatorsList[0].Address] = validator.lastBlock
 		})
 
+		return skip, nil, nil
+	}
+	runTest(t, testCase)
+}
+
+func TestAddIncorrectStakeholdersToList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	operatorKey, err := keygenerator.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	participantKey, err := keygenerator.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	once := sync.Once{}
+	operatorAddress := crypto.PubkeyToAddress(operatorKey.PublicKey)
+	testCase := &testCase{
+		name:                 "no malicious - 1 tx per second",
+		numValidators:        5,
+		numBlocks:            10,
+		txPerPeer:            1,
+		removedPeers:         make(map[common.Address]uint64),
+		sendTransactionHooks: make(map[string]func(validator *testNode, fromAddr common.Address, toAddr common.Address) (bool, *types.Transaction, error)),
+		genesisHook: func(g *core.Genesis) *core.Genesis {
+			g.Config.AutonityContractConfig.Operator = operatorAddress
+			g.Alloc[operatorAddress] = core.GenesisAccount{
+				Balance: big.NewInt(100000000000000000),
+			}
+			return g
+		},
+	}
+	testCase.sendTransactionHooks["VD"] = func(validator *testNode, _ common.Address, _ common.Address) (bool, *types.Transaction, error) { //nolint
+		if validator.lastBlock <= 3 {
+			return true, nil, nil
+		}
+		skip := true
+		once.Do(func() {
+			conn, err := ethclient.Dial("http://127.0.0.1:" + strconv.Itoa(validator.rpcPort))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+
+			nonce, err := conn.PendingNonceAt(context.Background(), operatorAddress)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gasPrice, err := conn.SuggestGasPrice(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			auth := bind.NewKeyedTransactor(operatorKey)
+			auth.From = operatorAddress
+			auth.Nonce = big.NewInt(int64(nonce))
+			auth.GasLimit = uint64(300000) // in units
+			auth.GasPrice = gasPrice
+
+			contractAddress := validator.service.BlockChain().GetAutonityContract().Address()
+			instance, err := NewAutonity(contractAddress, conn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pEnode:=enode.NewV4(&participantKey.PublicKey,net.ParseIP("127.0.0.1"), 8527, 8527)
+			_, err = instance.AddParticipant(auth, crypto.PubkeyToAddress(participantKey.PublicKey), pEnode.String())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			skip = false
+		})
+		return skip, nil, nil
+	}
+	runTest(t, testCase)
+}
+
+func TestAddStakeholderWithCorruptedEnodeToList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	operatorKey, err := keygenerator.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	participantKey, err := keygenerator.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	once := sync.Once{}
+	operatorAddress := crypto.PubkeyToAddress(operatorKey.PublicKey)
+	testCase := &testCase{
+		name:                 "no malicious - 1 tx per second",
+		numValidators:        5,
+		numBlocks:            10,
+		txPerPeer:            1,
+		removedPeers:         make(map[common.Address]uint64),
+		sendTransactionHooks: make(map[string]func(validator *testNode, fromAddr common.Address, toAddr common.Address) (bool, *types.Transaction, error)),
+		genesisHook: func(g *core.Genesis) *core.Genesis {
+			g.Config.AutonityContractConfig.Operator = operatorAddress
+			g.Alloc[operatorAddress] = core.GenesisAccount{
+				Balance: big.NewInt(100000000000000000),
+			}
+			return g
+		},
+	}
+	testCase.sendTransactionHooks["VD"] = func(validator *testNode, _ common.Address, _ common.Address) (bool, *types.Transaction, error) { //nolint
+		if validator.lastBlock <= 3 {
+			return true, nil, nil
+		}
+		skip := true
+		once.Do(func() {
+			conn, err := ethclient.Dial("http://127.0.0.1:" + strconv.Itoa(validator.rpcPort))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+
+			nonce, err := conn.PendingNonceAt(context.Background(), operatorAddress)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gasPrice, err := conn.SuggestGasPrice(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			auth := bind.NewKeyedTransactor(operatorKey)
+			auth.From = operatorAddress
+			auth.Nonce = big.NewInt(int64(nonce))
+			auth.GasLimit = uint64(300000) // in units
+			auth.GasPrice = gasPrice
+
+			contractAddress := validator.service.BlockChain().GetAutonityContract().Address()
+			instance, err := NewAutonity(contractAddress, conn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = instance.AddParticipant(auth, crypto.PubkeyToAddress(participantKey.PublicKey),"enode://some_bad_enode@127.0.0.1:8527")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			skip = false
+		})
 		return skip, nil, nil
 	}
 	runTest(t, testCase)

--- a/consensus/test/autonity_contract_test.go
+++ b/consensus/test/autonity_contract_test.go
@@ -406,7 +406,7 @@ func TestAddIncorrectStakeholdersToList(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			pEnode:=enode.NewV4(&participantKey.PublicKey,net.ParseIP("127.0.0.1"), 8527, 8527)
+			pEnode := enode.NewV4(&participantKey.PublicKey, net.ParseIP("127.0.0.1"), 8527, 8527)
 			_, err = instance.AddParticipant(auth, crypto.PubkeyToAddress(participantKey.PublicKey), pEnode.String())
 			if err != nil {
 				t.Fatal(err)
@@ -483,7 +483,7 @@ func TestAddStakeholderWithCorruptedEnodeToList(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = instance.AddParticipant(auth, crypto.PubkeyToAddress(participantKey.PublicKey),"enode://some_bad_enode@127.0.0.1:8527")
+			_, err = instance.AddParticipant(auth, crypto.PubkeyToAddress(participantKey.PublicKey), "enode://some_bad_enode@127.0.0.1:8527")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/contracts/autonity/calls.go
+++ b/contracts/autonity/calls.go
@@ -31,7 +31,7 @@ type ContractState struct {
 
 type raw []byte
 
-//// Instantiates a new EVM object which is required when creating or calling a deployed contract
+// Instantiates a new EVM object which is required when creating or calling a deployed contract
 func (ac *Contract) getEVM(header *types.Header, origin common.Address, statedb *state.StateDB) *vm.EVM {
 	coinbase, _ := types.Ecrecover(header)
 	evmContext := vm.Context{
@@ -57,13 +57,6 @@ func (ac *Contract) DeployAutonityContract(chain consensus.ChainReader, header *
 	contractBytecode := common.Hex2Bytes(chain.Config().AutonityContractConfig.Bytecode)
 	evm := ac.getEVM(header, chain.Config().AutonityContractConfig.Deployer, statedb)
 	sender := vm.AccountRef(chain.Config().AutonityContractConfig.Deployer)
-
-	//todo do we need it?
-	//validators, err = ac.SavedValidatorsRetriever(1)
-	//sort.Sort(validators)
-
-	//We need to append to data the constructor's parameters
-	//That should always be genesis validators
 
 	contractABI, err := ac.abi()
 
@@ -91,7 +84,7 @@ func (ac *Contract) DeployAutonityContract(chain consensus.ChainReader, header *
 		accTypes = append(accTypes, big.NewInt(int64(v.Type.GetID())))
 		participantStake = append(participantStake, big.NewInt(int64(v.Stake)))
 
-		//TODO: default commission rate is 0, should use a config file...
+		// TODO: default commission rate is 0, should use a config file...
 		commissionRate = append(commissionRate, big.NewInt(0))
 	}
 

--- a/contracts/autonity/economic_metric.go
+++ b/contracts/autonity/economic_metric.go
@@ -108,7 +108,6 @@ func (em *EconomicMetrics) recordMetric(name string, value *big.Int, isWei bool)
 
 // measure metrics of user's meta data by regarding of network economic.
 func (em *EconomicMetrics) SubmitEconomicMetrics(v *EconomicMetaData, stateDB *state.StateDB, height uint64, operator common.Address) {
-
 	if v == nil || stateDB == nil {
 		return
 	}
@@ -131,18 +130,23 @@ func (em *EconomicMetrics) SubmitEconomicMetrics(v *EconomicMetaData, stateDB *s
 		rate := v.Commissionrates[i]
 		balance := stateDB.GetBalance(user)
 
-		log.Debug("Economic data retrieved", "user: ", user, "userType: ", userType, "stake: ", stake, "rate: ", rate, "balance: ", balance)
+		log.Debug("Economic data retrieved",
+			"user", user,
+			"userType", userType,
+			"stake", stake,
+			"rate", rate,
+			"balance", balance)
 
 		// generate metric ID.
-		stakeID, balanceID, commmissionRateID, err := em.generateUserMetricsID(user, userType)
+		stakeID, balanceID, commissionRateID, err := em.generateUserMetricsID(user, userType)
 		if err != nil {
-			log.Warn("generateUserMetricsID failed.")
+			log.Warn("generateUserMetricsID failed")
 			return
 		}
 
 		em.recordMetric(stakeID, stake, false)
 		em.recordMetric(balanceID, balance, true)
-		em.recordMetric(commmissionRateID, rate, false)
+		em.recordMetric(commissionRateID, rate, false)
 	}
 
 	// clean up useless metrics if there exists.
@@ -151,7 +155,7 @@ func (em *EconomicMetrics) SubmitEconomicMetrics(v *EconomicMetaData, stateDB *s
 
 func (em *EconomicMetrics) SubmitRewardDistributionMetrics(v *RewardDistributionMetaData, height uint64) {
 	if len(v.Holders) != len(v.Rewardfractions) {
-		log.Warn("Reward fractions does not distribute to all stake holder.")
+		log.Warn("Reward fractions does not distribute to all stake holder")
 		return
 	}
 

--- a/core/types/nodes.go
+++ b/core/types/nodes.go
@@ -1,12 +1,12 @@
 package types
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 
 	"github.com/clearmatics/autonity/log"
 	"github.com/clearmatics/autonity/p2p/enode"
-	"github.com/davecgh/go-spew/spew"
 )
 
 type Nodes struct {
@@ -51,7 +51,13 @@ func NewNodes(strList []string) *Nodes {
 	}
 
 	if len(errs) != 0 {
-		log.Error("enodes parse errors", "errs", spew.Sdump(errs))
+		var msg string
+		for _, err := range errs {
+			if err != nil {
+				msg += fmt.Sprintf("%v\n", err)
+			}
+		}
+		log.Error("enodes parse errors", "errs", msg)
 	}
 
 	return filterNodes(n)

--- a/helloworld/autonity-start.sh
+++ b/helloworld/autonity-start.sh
@@ -33,6 +33,7 @@ $AUTONITY \
   --rpccorsdomain "*" \
   --syncmode "full" \
   --mine \
+  --allow-insecure-unlock \
   --miner.threads 1 \
   --verbosity 4 \
   --debug

--- a/helloworld/genesis-tendermint.json
+++ b/helloworld/genesis-tendermint.json
@@ -18,7 +18,7 @@
       "bytecode": "",
       "abi": "",
       "minGasPrice": 5000,
-      "operator": "0x4ad219b58a5b46a1d9662beaa6a70db9f570dea5",
+      "operator": "0x4b07239bd581d21aefcdee0c6db38070f9a5fd2d",
       "users": [
         { "enode": "enode://d73b857969c86415c0c000371bcebd9ed3cca6c376032b3f65e58e9e2b79276fbc6f59eb1e22fcd6356ab95f42a666f70afd4985933bd8f3e05beb1a2bf8fdde@172.25.0.11:30303", "type": "validator", "stake": 10000 },
         { "enode": "enode://1f207dfb3bcbbd338fbc991ec13e40d204b58fe7275cea48cfeb53c2c24e1071e1b4ef2959325fe48a5893de8ff37c73a24a412f367e505e5dec832813da546a@172.25.0.12:30303", "type": "validator", "stake": 10000 },

--- a/p2p/discv5/node_test.go
+++ b/p2p/discv5/node_test.go
@@ -141,7 +141,7 @@ var parseNodeTests = []struct {
 	{
 		// This test checks that errors from url.Parse are handled.
 		rawurl:    "://foo",
-		wantError: `parse ://foo: missing protocol scheme`,
+		wantError: `parse "://foo": missing protocol scheme`,
 	},
 }
 

--- a/p2p/discv5/node_test.go
+++ b/p2p/discv5/node_test.go
@@ -148,12 +148,19 @@ var parseNodeTests = []struct {
 func TestParseNode(t *testing.T) {
 	for _, test := range parseNodeTests {
 		n, err := ParseNode(test.rawurl)
-		if test.wantError != "" {
+		var gotErr string
+		if err != nil {
+			gotErr = strings.ReplaceAll(err.Error(), "\"", "")
+		}
+
+		wantError := strings.ReplaceAll(test.wantError, "\"", "")
+
+		if wantError != "" {
 			if err == nil {
-				t.Errorf("test %q:\n  got nil error, expected %#q", test.rawurl, test.wantError)
+				t.Errorf("test %q:\n  got nil error, expected %#q", test.rawurl, wantError)
 				continue
-			} else if !strings.Contains(err.Error(), test.wantError) {
-				t.Errorf("test %q:\n  got error %#q, expected %#q", test.rawurl, err.Error(), test.wantError)
+			} else if !strings.Contains(gotErr, wantError) {
+				t.Errorf("test %q:\n  got error %#q, expected %#q", test.rawurl, gotErr, wantError)
 				continue
 			}
 		} else {

--- a/p2p/enode/resolver.go
+++ b/p2p/enode/resolver.go
@@ -11,13 +11,13 @@ import (
 )
 
 const (
-	maxParseTries     = 300
-	delayBetweenTries = time.Second
+	maxParseTries     = 3
+	delayBetweenTries = 5 * time.Second
 	resolveSetTTL     = 10 * time.Minute
 )
 
 var rs *resolveSet
-
+var NotParsedErr = errors.New("not parsed")
 func init() {
 	rs = NewResolveSet()
 }
@@ -76,7 +76,16 @@ func (rs *resolveSet) Start(resoveCycleSleepDuration time.Duration) {
 
 				node, err := rs.ParseV4WithResolveMaxTry(en, rs.maxTries, rs.delayBetweenTries)
 				if err != nil {
-					log.Warn("Node not resolved", "enode", en)
+					if err==NotParsedErr  {
+						log.Warn("Node not resolved", "enode", en)
+						continue
+					}
+					if _, ok:=errors.Unwrap(err).(*net.DNSError); ok {
+						log.Warn("Node not resolved", "enode", en, "err", err)
+						continue
+					}
+
+					delete(rs.resolveSet, en)
 					continue
 				}
 
@@ -121,11 +130,16 @@ func (rs *resolveSet) ParseV4WithResolveMaxTry(rawurl string, maxTry int, wait t
 		if err == nil {
 			break
 		}
+		if _, ok:=err.(*net.DNSError); ok {
+			log.Warn("trying to parse", "enode", rawurl, "attempt", i, "err", err)
+		} else {
+			return nil, err
+		}
+
 		time.Sleep(wait)
-		log.Error("trying to parse", "enode", rawurl, "attempt", i, "err", err)
 	}
 	if node == nil {
-		return nil, errors.New("have not parsed")
+		return nil, NotParsedErr
 	}
 	return node, err
 
@@ -148,7 +162,7 @@ func (rs *resolveSet) Get(enodeStr string) (*Node, error) {
 			rs.addNoLock(enodeStr)
 		}
 		rs.Unlock()
-		node, err = rs.ParseV4WithResolveMaxTry(enodeStr, rs.maxTries, rs.delayBetweenTries)
+		node, err = rs.ParseV4WithResolveMaxTry(enodeStr, 1, rs.delayBetweenTries)
 		if err != nil {
 			return nil, err
 		}

--- a/p2p/enode/resolver.go
+++ b/p2p/enode/resolver.go
@@ -18,6 +18,7 @@ const (
 
 var rs *resolveSet
 var NotParsedErr = errors.New("not parsed")
+
 func init() {
 	rs = NewResolveSet()
 }
@@ -76,11 +77,11 @@ func (rs *resolveSet) Start(resoveCycleSleepDuration time.Duration) {
 
 				node, err := rs.ParseV4WithResolveMaxTry(en, rs.maxTries, rs.delayBetweenTries)
 				if err != nil {
-					if err==NotParsedErr  {
+					if err == NotParsedErr {
 						log.Warn("Node not resolved", "enode", en)
 						continue
 					}
-					if _, ok:=errors.Unwrap(err).(*net.DNSError); ok {
+					if _, ok := errors.Unwrap(err).(*net.DNSError); ok {
 						log.Warn("Node not resolved", "enode", en, "err", err)
 						continue
 					}
@@ -130,7 +131,7 @@ func (rs *resolveSet) ParseV4WithResolveMaxTry(rawurl string, maxTry int, wait t
 		if err == nil {
 			break
 		}
-		if _, ok:=err.(*net.DNSError); ok {
+		if _, ok := err.(*net.DNSError); ok {
 			log.Warn("trying to parse", "enode", rawurl, "attempt", i, "err", err)
 		} else {
 			return nil, err

--- a/p2p/enode/resolver.go
+++ b/p2p/enode/resolver.go
@@ -17,7 +17,7 @@ const (
 )
 
 var rs *resolveSet
-var NotParsedErr = errors.New("not parsed")
+var ErrCannotParse = errors.New("not parsed")
 
 func init() {
 	rs = NewResolveSet()
@@ -77,7 +77,7 @@ func (rs *resolveSet) Start(resoveCycleSleepDuration time.Duration) {
 
 				node, err := rs.ParseV4WithResolveMaxTry(en, rs.maxTries, rs.delayBetweenTries)
 				if err != nil {
-					if err == NotParsedErr {
+					if err == ErrCannotParse {
 						log.Warn("Node not resolved", "enode", en)
 						continue
 					}
@@ -140,7 +140,7 @@ func (rs *resolveSet) ParseV4WithResolveMaxTry(rawurl string, maxTry int, wait t
 		time.Sleep(wait)
 	}
 	if node == nil {
-		return nil, NotParsedErr
+		return nil, ErrCannotParse
 	}
 	return node, err
 

--- a/p2p/enode/resolver_test.go
+++ b/p2p/enode/resolver_test.go
@@ -34,7 +34,6 @@ func TestAsyncResolver(t *testing.T) {
 	}
 
 	successResolveEnode := "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@domainsuccess.com"
-
 	failResolveEnode := "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@domainfail.com"
 
 	v, err := rs.ParseV4WithResolve(failResolveEnode)
@@ -77,7 +76,7 @@ func TestAsyncResolver(t *testing.T) {
 		t.Fatal()
 	}
 	if !okFail {
-		t.Fatal()
+		t.Fatal(failResolveEnode)
 	}
 
 }

--- a/p2p/enode/resolver_test.go
+++ b/p2p/enode/resolver_test.go
@@ -22,7 +22,7 @@ func TestAsyncResolver(t *testing.T) {
 
 		case "domainfail.com":
 			if atomic.LoadInt32(failResolved) != 1 {
-				return nil, errors.New("resolve err")
+				return nil, &net.DNSError{}
 			}
 			return []net.IP{
 				net.ParseIP("127.0.0.1"),
@@ -69,7 +69,7 @@ func TestAsyncResolver(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	rs.RLock()
-	v, okFail = rs.cache[failResolveEnode]
+	_, okFail = rs.cache[failResolveEnode]
 	_, okSuccess = rs.cache[successResolveEnode]
 	rs.RUnlock()
 

--- a/p2p/enode/url4_resolve_test.go
+++ b/p2p/enode/url4_resolve_test.go
@@ -135,7 +135,7 @@ var parseNodeWithResolveTests = []struct {
 	{
 		// This test checks that errors from url.Parse are handled.
 		rawurl:    "://foo",
-		wantError: `parse ://foo: missing protocol scheme`,
+		wantError: `parse "://foo": missing protocol scheme`,
 	},
 }
 

--- a/p2p/enode/url4_resolve_test.go
+++ b/p2p/enode/url4_resolve_test.go
@@ -142,12 +142,19 @@ var parseNodeWithResolveTests = []struct {
 func TestParseNodeWithDomainResolution(t *testing.T) {
 	for _, test := range parseNodeWithResolveTests {
 		n, err := ParseV4WithResolve(test.rawurl)
-		if strings.ReplaceAll(test.wantError, "\"", "") != "" {
+
+		var gotErr string
+		if err != nil {
+			gotErr = strings.ReplaceAll(err.Error(), "\"", "")
+		}
+
+		wantError := strings.ReplaceAll(test.wantError, "\"", "")
+		if wantError != "" {
 			if err == nil {
-				t.Errorf("test %q:\n  got nil error, expected %#q", test.rawurl, test.wantError)
+				t.Errorf("test %q:\n  got nil error, expected %#q", test.rawurl, wantError)
 				continue
-			} else if !strings.Contains(err.Error(), test.wantError) {
-				t.Errorf("test %q:\n  got error %#q, expected %#q\n%v", test.rawurl, err.Error(), test.wantError, n)
+			} else if !strings.Contains(gotErr, wantError) {
+				t.Errorf("test %q:\n  got error %#q, expected %#q\n%v", test.rawurl, gotErr, wantError, n)
 				continue
 			}
 		} else {

--- a/p2p/enode/url4_resolve_test.go
+++ b/p2p/enode/url4_resolve_test.go
@@ -142,7 +142,7 @@ var parseNodeWithResolveTests = []struct {
 func TestParseNodeWithDomainResolution(t *testing.T) {
 	for _, test := range parseNodeWithResolveTests {
 		n, err := ParseV4WithResolve(test.rawurl)
-		if test.wantError != "" {
+		if strings.ReplaceAll(test.wantError, "\"", "") != "" {
 			if err == nil {
 				t.Errorf("test %q:\n  got nil error, expected %#q", test.rawurl, test.wantError)
 				continue

--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -36,6 +36,14 @@ var (
 	lookupIPFunc      = net.LookupIP
 )
 
+var (
+	ErrHostResolution   = errors.New("invalid domain or IP address")
+	ErrInvalidPublicKey = errors.New("invalid public key")
+	ErrInvalidPort      = errors.New("invalid port")
+	ErrInvalidDisport   = errors.New("invalid discport in query")
+	ErrInvalidHost      = errors.New("invalid host")
+)
+
 const defaultPort = ":30303"
 
 // MustParseV4 parses a node URL. It panics if the URL is not valid.
@@ -79,7 +87,7 @@ func parseV4(rawurl string, resolve func(host string) ([]net.IP, error)) (*Node,
 	if m := incompleteNodeURL.FindStringSubmatch(rawurl); m != nil {
 		id, err := parsePubkey(m[1])
 		if err != nil {
-			return nil, fmt.Errorf("invalid public key (%v)", err)
+			return nil, fmt.Errorf("%w (%v)", ErrInvalidPublicKey, err)
 		}
 		return NewV4(id, nil, 0, 0), nil
 	}
@@ -141,17 +149,31 @@ func parseComplete(rawurl string, resolveFunc func(host string) ([]net.IP, error
 	// Parse the IP address.
 	host, port, err := net.SplitHostPort(u.Host)
 	if err != nil {
-		return nil, fmt.Errorf("invalid host: %v", err)
+		return nil, fmt.Errorf("%w: %v", ErrInvalidHost, err)
+	}
+
+	// Parse the port numbers.
+	if tcpPort, err = strconv.ParseUint(port, 10, 16); err != nil {
+		return nil, ErrInvalidPort
+	}
+
+	udpPort = tcpPort
+	qv := u.Query()
+	if qv.Get("discport") != "" {
+		udpPort, err = strconv.ParseUint(qv.Get("discport"), 10, 16)
+		if err != nil {
+			return nil, ErrInvalidDisport
+		}
 	}
 
 	if ip = net.ParseIP(host); ip == nil {
 		if resolveFunc == nil {
-			return nil, errors.New("invalid IP address")
+			return nil, fmt.Errorf("%w (%v)", ErrHostResolution, errors.New("invalid IP address"))
 		}
 		// if host is not IPV4/6, resolve host is a domain
 		ips, err := resolveFunc(host)
 		if err != nil {
-			return NewV4(id, nil, 0, 0), fmt.Errorf("invalid domain or IP address: %w", err)
+			return NewV4(id, nil, 0, 0), fmt.Errorf("%w (%v)", ErrHostResolution, err)
 		}
 		if len(ips) > 1 {
 			ip = ips[len(ips)-1]
@@ -161,18 +183,6 @@ func parseComplete(rawurl string, resolveFunc func(host string) ([]net.IP, error
 		// Ensure the IP is 4 bytes long for IPv4 addresses.
 		if ipv4 := ip.To4(); ipv4 != nil {
 			ip = ipv4
-		}
-	}
-	// Parse the port numbers.
-	if tcpPort, err = strconv.ParseUint(port, 10, 16); err != nil {
-		return nil, errors.New("invalid port")
-	}
-	udpPort = tcpPort
-	qv := u.Query()
-	if qv.Get("discport") != "" {
-		udpPort, err = strconv.ParseUint(qv.Get("discport"), 10, 16)
-		if err != nil {
-			return nil, errors.New("invalid discport in query")
 		}
 	}
 	return NewV4(id, ip, int(tcpPort), int(udpPort)), nil

--- a/p2p/enode/urlv4_test.go
+++ b/p2p/enode/urlv4_test.go
@@ -158,12 +158,19 @@ func hexPubkey(h string) *ecdsa.PublicKey {
 func TestParseNode(t *testing.T) {
 	for _, test := range parseNodeTests {
 		n, err := Parse(ValidSchemes, test.input)
-		if test.wantError != "" {
+		var gotErr string
+		if err != nil {
+			gotErr = strings.ReplaceAll(err.Error(), "\"", "")
+		}
+
+		wantError := strings.ReplaceAll(test.wantError, "\"", "")
+
+		if wantError != "" {
 			if err == nil {
-				t.Errorf("test %q:\n  got nil error, expected %#q", test.input, test.wantError)
+				t.Errorf("test %q:\n  got nil error, expected %#q", test.input, wantError)
 				continue
-			} else if !strings.Contains(err.Error(), test.wantError) {
-				t.Errorf("test %q:\n  got error %#q, expected %#q\n%v", test.input, err.Error(), test.wantError, n)
+			} else if !strings.Contains(gotErr, wantError) {
+				t.Errorf("test %q:\n  got error %#q, expected %#q\n%v", test.input, gotErr, wantError, n)
 				continue
 			}
 		} else {


### PR DESCRIPTION
This PR fixes #451 by adding error handling for cases when an invalid e-node is added. The lack of this led to a long resolution cycle which drastically slowed down the consensus. (One block per 3 minutes). 