### PR TITLE
Remove duplicated config struct

### DIFF
--- a/consensus/tendermint/backend/backend_test.go
+++ b/consensus/tendermint/backend/backend_test.go
@@ -711,7 +711,7 @@ func getGenesisAndKeys(n int) (*core.Genesis, []*ecdsa.PrivateKey) {
 	genesis.GasLimit = 10000000
 	genesis.Config.AutonityContractConfig = &params.AutonityContractGenesis{}
 	// force enable Istanbul engine
-	genesis.Config.Tendermint = &params.TendermintConfig{}
+	genesis.Config.Tendermint = &config.Config{}
 	genesis.Config.Ethash = nil
 	genesis.Difficulty = defaultDifficulty
 	genesis.Nonce = emptyNonce.Uint64()

--- a/consensus/tendermint/config/config.go
+++ b/consensus/tendermint/config/config.go
@@ -28,12 +28,15 @@ const (
 )
 
 type Config struct {
-	RequestTimeout uint64         `toml:",omitempty"` // The timeout for each Istanbul round in milliseconds.
-	BlockPeriod    uint64         `toml:",omitempty"` // Default minimum difference between two consecutive block's timestamps in second
-	ProposerPolicy ProposerPolicy `toml:",omitempty"` // The policy for proposer selection
-	Epoch          uint64         `toml:",omitempty"` // The number of blocks after which to checkpoint and reset the pending votes
-
+	RequestTimeout uint64         `toml:",omitempty" json:"request-timeout"` // The timeout for each Istanbul round in milliseconds.
+	BlockPeriod    uint64         `toml:",omitempty" json:"block-period"`    // Default minimum difference between two consecutive block's timestamps in second
+	ProposerPolicy ProposerPolicy `toml:",omitempty" json:"policy"`          // The policy for proposer selection
+	Epoch          uint64         `toml:",omitempty" json:"epoch"`           // The number of blocks after which to checkpoint and reset the pending votes
 	sync.RWMutex
+}
+
+func (c *Config) String() string {
+	return "tendermint"
 }
 
 func DefaultConfig() *Config {

--- a/consensus/test/test_helpers_test.go
+++ b/consensus/test/test_helpers_test.go
@@ -88,7 +88,7 @@ func makeGenesis(nodes map[string]*testNode) *core.Genesis {
 	genesis.Mixhash = types.BFTDigest
 
 	genesis.Config = params.TestChainConfig
-	genesis.Config.Tendermint = &params.TendermintConfig{}
+	genesis.Config.Tendermint = &config.Config{}
 	genesis.Config.Ethash = nil
 	genesis.Config.AutonityContractConfig = &params.AutonityContractGenesis{}
 

--- a/params/config.go
+++ b/params/config.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 
 	"github.com/clearmatics/autonity/common"
+	tendermint "github.com/clearmatics/autonity/consensus/tendermint/config"
 	"github.com/clearmatics/autonity/crypto"
 )
 
@@ -284,7 +285,7 @@ type ChainConfig struct {
 
 	// Various consensus engines
 	Ethash                 *EthashConfig            `json:"ethash,omitempty"`
-	Tendermint             *TendermintConfig        `json:"tendermint,omitempty"`
+	Tendermint             *tendermint.Config       `json:"tendermint,omitempty"`
 	AutonityContractConfig *AutonityContractGenesis `json:"autonityContract,omitempty"`
 }
 
@@ -294,19 +295,6 @@ type EthashConfig struct{}
 // String implements the stringer interface, returning the consensus engine details.
 func (c *EthashConfig) String() string {
 	return "ethash"
-}
-
-// TendermintConfig is the consensus engine configs for Tendermint based sealing.
-type TendermintConfig struct {
-	Epoch          uint64 `json:"epoch"`  // Epoch length to reset votes and checkpoint
-	ProposerPolicy uint64 `json:"policy"` // The policy for proposer selection
-	BlockPeriod    uint64 `json:"block-period"`
-	RequestTimeout uint64 `json:"request-timeout"`
-}
-
-// String implements the stringer interface, returning the consensus engine details.
-func (c *TendermintConfig) String() string {
-	return "tendermint"
 }
 
 // String implements the fmt.Stringer interface.


### PR DESCRIPTION
A simple cleanup that removes the `TendermintConfig` struct, which was a duplication of the `tendermint/config/Config` struct.