### PR TITLE
Remove unused fields

### DIFF
--- a/cmd/autonity/chaincmd.go
+++ b/cmd/autonity/chaincmd.go
@@ -255,18 +255,8 @@ func setupDefaults(genesis *core.Genesis) {
 	defaultConfig := config.DefaultConfig()
 
 	if genesis.Config.Tendermint != nil {
-		if genesis.Config.Tendermint.Epoch == 0 {
-			genesis.Config.Tendermint.Epoch = defaultConfig.Epoch
-		}
-		if genesis.Config.Tendermint.RequestTimeout == 0 {
-			genesis.Config.Tendermint.RequestTimeout = defaultConfig.RequestTimeout
-		}
 		if genesis.Config.Tendermint.BlockPeriod == 0 {
 			genesis.Config.Tendermint.BlockPeriod = defaultConfig.BlockPeriod
-		}
-
-		if genesis.Config.Tendermint.Epoch == 0 {
-			genesis.Config.Tendermint.Epoch = defaultConfig.Epoch
 		}
 	}
 }

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -59,13 +59,6 @@ var (
 
 // New creates an Ethereum Backend for BFT core engine.
 func New(config *tendermintConfig.Config, privateKey *ecdsa.PrivateKey, db ethdb.Database, chainConfig *params.ChainConfig, vmConfig *vm.Config) *Backend {
-	if chainConfig.Tendermint.Epoch != 0 {
-		config.Epoch = chainConfig.Tendermint.Epoch
-	}
-
-	if chainConfig.Tendermint.RequestTimeout != 0 {
-		config.RequestTimeout = chainConfig.Tendermint.RequestTimeout
-	}
 	if chainConfig.Tendermint.BlockPeriod != 0 {
 		config.BlockPeriod = chainConfig.Tendermint.BlockPeriod
 	}

--- a/consensus/tendermint/backend/engine_test.go
+++ b/consensus/tendermint/backend/engine_test.go
@@ -191,7 +191,6 @@ func TestVerifyHeader(t *testing.T) {
 	}
 	header = block.Header()
 	copy(header.Nonce[:], hexutil.MustDecode("0x111111111111"))
-	header.Number = big.NewInt(int64(engine.config.Epoch))
 	err = engine.VerifyHeader(chain, header, false)
 	if err != errInvalidNonce {
 		t.Errorf("error mismatch: have %v, want %v", err, errInvalidNonce)

--- a/consensus/tendermint/config/config.go
+++ b/consensus/tendermint/config/config.go
@@ -28,10 +28,8 @@ const (
 )
 
 type Config struct {
-	RequestTimeout uint64         `toml:",omitempty" json:"request-timeout"` // The timeout for each Istanbul round in milliseconds.
-	BlockPeriod    uint64         `toml:",omitempty" json:"block-period"`    // Default minimum difference between two consecutive block's timestamps in second
-	ProposerPolicy ProposerPolicy `toml:",omitempty" json:"policy"`          // The policy for proposer selection
-	Epoch          uint64         `toml:",omitempty" json:"epoch"`           // The number of blocks after which to checkpoint and reset the pending votes
+	BlockPeriod    uint64         `toml:",omitempty" json:"block-period"` // Default minimum difference between two consecutive block's timestamps in second
+	ProposerPolicy ProposerPolicy `toml:",omitempty" json:"policy"`       // The policy for proposer selection
 	sync.RWMutex
 }
 
@@ -41,10 +39,8 @@ func (c *Config) String() string {
 
 func DefaultConfig() *Config {
 	return &Config{
-		RequestTimeout: 10000,
 		BlockPeriod:    1,
 		ProposerPolicy: RoundRobin,
-		Epoch:          30000,
 	}
 }
 


### PR DESCRIPTION
A very simple PR that just removes fields from `consensus/tendermint/config.Config` that are no longer used.