### PR TITLE
Remove genesis committee field

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -128,7 +128,11 @@ func runCmd(ctx *cli.Context) error {
 		gen := readGenesis(ctx.GlobalString(GenesisFlag.Name))
 		genesisConfig = gen
 		db := rawdb.NewMemoryDatabase()
-		genesis := gen.ToBlock(db)
+		genesis, err := gen.ToBlock(db)
+		if err != nil {
+			return err
+		}
+
 		statedb, _ = state.New(genesis.Root(), state.NewDatabase(db))
 		chainConfig = gen.Config
 	} else {

--- a/consensus/tendermint/backend/backend_test.go
+++ b/consensus/tendermint/backend/backend_test.go
@@ -748,10 +748,6 @@ func AppendValidators(genesis *core.Genesis, addrs []common.Address) {
 				Enode:   EnodeStub,
 				Stake:   100,
 			})
-		genesis.Committee = append(genesis.Committee, types.CommitteeMember{
-			Address:     addrs[i],
-			VotingPower: new(big.Int).SetUint64(1),
-		})
 	}
 }
 

--- a/consensus/test/test_helpers_test.go
+++ b/consensus/test/test_helpers_test.go
@@ -157,11 +157,6 @@ func makeGenesis(nodes map[string]*testNode, stakeholderName string) *core.Genes
 		panic(err)
 	}
 
-	err = genesis.SetBFT()
-	if err != nil {
-		panic(err)
-	}
-
 	return genesis
 }
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -271,6 +271,9 @@ func (g *Genesis) ToBlock(db ethdb.Database) (*types.Block, error) {
 
 	var committee types.Committee
 	if g.Config.AutonityContractConfig != nil {
+		if g.Difficulty.Cmp(big.NewInt(1)) != 0 {
+			return nil, fmt.Errorf("autonity requires genesis to have a difficulty of 1, instead got %v", g.Difficulty)
+		}
 		var err error
 		committee, err = extractCommittee(g.Config.AutonityContractConfig.Users)
 		if err != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -63,9 +63,6 @@ type Genesis struct {
 	GasUsed    uint64      `json:"gasUsed"`
 	ParentHash common.Hash `json:"parentHash"`
 
-	//PoS Fields
-	Committee types.Committee `json:"committee"           gencodec:"required"`
-
 	mu sync.RWMutex
 }
 
@@ -104,7 +101,6 @@ type genesisSpecMarshaling struct {
 	Difficulty *math.HexOrDecimal256
 	Alloc      map[common.UnprefixedAddress]GenesisAccount
 
-	Committee    []common.UnprefixedAddress
 	VotingPowers []math.HexOrDecimal64
 }
 
@@ -191,7 +187,11 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 			genesis = DefaultGenesisBlock()
 		}
 		// Ensure the stored genesis matches with the given one.
-		hash := genesis.ToBlock(nil).Hash()
+		b, err := genesis.ToBlock(nil)
+		if err != nil {
+			return nil, common.Hash{}, err
+		}
+		hash := b.Hash()
 		if hash != stored {
 			return genesis.Config, hash, &GenesisMismatchError{stored, hash}
 		}
@@ -204,7 +204,11 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 
 	// Check whether the genesis block is already written.
 	if genesis != nil {
-		hash := genesis.ToBlock(nil).Hash()
+		b, err := genesis.ToBlock(nil)
+		if err != nil {
+			return nil, common.Hash{}, err
+		}
+		hash := b.Hash()
 		if hash != stored {
 			return genesis.Config, hash, &GenesisMismatchError{stored, hash}
 		}
@@ -263,7 +267,17 @@ func (g *Genesis) configOrDefault(ghash common.Hash) *params.ChainConfig {
 
 // ToBlock creates the genesis block and writes state of a genesis specification
 // to the given database (or discards it if nil).
-func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
+func (g *Genesis) ToBlock(db ethdb.Database) (*types.Block, error) {
+
+	var committee types.Committee
+	if g.Config.AutonityContractConfig != nil {
+		var err error
+		committee, err = extractCommittee(g.Config.AutonityContractConfig.Users)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if db == nil {
 		db = rawdb.NewMemoryDatabase()
 	}
@@ -299,8 +313,8 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 		MixDigest:  g.Mixhash,
 		Coinbase:   g.Coinbase,
 		Root:       root,
-		Committee:  g.Committee,
 		Round:      0,
+		Committee:  committee,
 	}
 	if g.GasLimit == 0 {
 		head.GasLimit = params.GenesisGasLimit
@@ -308,7 +322,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	statedb.Commit(false)
 	statedb.Database().TrieDB().Commit(root, true)
 
-	return types.NewBlock(head, nil, nil, nil)
+	return types.NewBlock(head, nil, nil, nil), nil
 }
 
 // Commit writes the block and state of a genesis specification to the database.
@@ -322,17 +336,15 @@ func (g *Genesis) Commit(db ethdb.Database) (*types.Block, error) {
 		return nil, err
 	}
 
-	if g.Config != nil && g.Config.Tendermint != nil {
-		err := g.SetBFT()
-		if err != nil {
-			return nil, err
-		}
+	block, err := g.ToBlock(db)
+	if err != nil {
+		return nil, err
 	}
 
-	block := g.ToBlock(db)
 	if block.Number().Sign() != 0 {
 		return nil, fmt.Errorf("can't commit genesis block with number > 0")
 	}
+
 	g.mu.RLock()
 	rawdb.WriteTd(db, block.Hash(), block.NumberU64(), g.Difficulty)
 	g.mu.RUnlock()
@@ -357,11 +369,12 @@ func (g *Genesis) Commit(db ethdb.Database) (*types.Block, error) {
 	return block, nil
 }
 
-// SetBFT sets default BFT(IBFT or Tendermint) config values
-func (g *Genesis) SetBFT() error {
-
+// extractCommittee takes a slice of autonity users and extracts the validators
+// into a new type 'types.Committee' which is returned. It returns an error if
+// the provided users contained no validators.
+func extractCommittee(users []params.User) (types.Committee, error) {
 	var committee types.Committee
-	for _, v := range g.Config.AutonityContractConfig.Users {
+	for _, v := range users {
 		if v.Type == params.UserValidator {
 			member := types.CommitteeMember{
 				Address:     v.Address,
@@ -371,21 +384,13 @@ func (g *Genesis) SetBFT() error {
 		}
 	}
 
-	if len(committee) == 0 { // we already have this check before, but just to make sure..
-		return fmt.Errorf("autonity Network requires at least 1 validator")
+	if len(committee) == 0 {
+		return nil, fmt.Errorf("no validators specified in the initial autonity users")
 	}
 
 	sort.Sort(committee)
-	g.Committee = committee
-
 	log.Info("starting BFT consensus", "validators", committee)
-
-	// we have to use '1' to have TD == BlockNumber for xBFT consensus
-	g.mu.Lock()
-	g.Difficulty = big.NewInt(1)
-	g.mu.Unlock()
-
-	return nil
+	return committee, nil
 }
 
 // MustCommit writes the genesis block and state to db, panicking on error.

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/clearmatics/autonity/common"
 	"github.com/clearmatics/autonity/consensus/ethash"
@@ -32,11 +33,13 @@ import (
 )
 
 func TestDefaultGenesisBlock(t *testing.T) {
-	block := DefaultGenesisBlock().ToBlock(nil)
+	block, err := DefaultGenesisBlock().ToBlock(nil)
+	assert.NoError(t, err)
 	if block.Hash() != params.MainnetGenesisHash {
 		t.Errorf("wrong mainnet genesis hash, got %v, want %v", block.Hash(), params.MainnetGenesisHash)
 	}
-	block = DefaultTestnetGenesisBlock().ToBlock(nil)
+	block, err = DefaultTestnetGenesisBlock().ToBlock(nil)
+	assert.NoError(t, err)
 	if block.Hash() != params.TestnetGenesisHash {
 		t.Errorf("wrong testnet genesis hash, got %v, want %v", block.Hash(), params.TestnetGenesisHash)
 	}

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -497,7 +497,10 @@ func testCheckpointChallenge(t *testing.T, syncmode downloader.SyncMode, checkpo
 		t.Fatal(err)
 	}
 
-	(&core.Genesis{Config: config}).MustCommit(db) // Commit genesis block
+	(&core.Genesis{
+		Config:     config,
+		Difficulty: big.NewInt(1),
+	}).MustCommit(db) // Commit genesis block
 	// If checkpointing is enabled, create and inject a fake CHT and the corresponding
 	// chllenge response.
 	var response *types.Header

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -59,8 +59,9 @@ func newTestProtocolManager(mode downloader.SyncMode, blocks int, generator func
 		engine = ethash.NewFaker()
 		db     = rawdb.NewMemoryDatabase()
 		gspec  = &core.Genesis{
-			Config: params.TestChainConfig,
-			Alloc:  core.GenesisAlloc{testBank: {Balance: big.NewInt(1000000)}},
+			Config:     params.TestChainConfig,
+			Alloc:      core.GenesisAlloc{testBank: {Balance: big.NewInt(1000000)}},
+			Difficulty: big.NewInt(1),
 		}
 	)
 	gspec.Config.AutonityContractConfig = &params.AutonityContractGenesis{

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -64,7 +64,11 @@ func newTestProtocolManager(mode downloader.SyncMode, blocks int, generator func
 		}
 	)
 	gspec.Config.AutonityContractConfig = &params.AutonityContractGenesis{
-		Users: []params.User{},
+		Users: []params.User{{
+			Address: common.HexToAddress("0x0000000000000000000000000000000000000000"),
+			Type:    params.UserValidator,
+			Stake:   1,
+		}},
 	}
 
 	for i := range peers {

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -18,6 +18,7 @@ package eth
 
 import (
 	"fmt"
+	"math/big"
 	"sync"
 	"testing"
 	"time"
@@ -194,7 +195,10 @@ func testSendTransactions(t *testing.T, protocol int) {
 		pow    = ethash.NewFaker()
 		db     = rawdb.NewMemoryDatabase()
 		config = &params.ChainConfig{}
-		gspec  = &core.Genesis{Config: config}
+		gspec  = &core.Genesis{
+			Config:     config,
+			Difficulty: big.NewInt(1),
+		}
 	)
 	config.AutonityContractConfig = &params.AutonityContractGenesis{}
 

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/clearmatics/autonity/eth"
 	"github.com/clearmatics/autonity/node"
 	"github.com/clearmatics/autonity/params"
+	"github.com/stretchr/testify/assert"
 )
 
 // Verify that Client implements the ethereum interfaces.
@@ -170,7 +171,8 @@ var (
 
 func newTestBackend(t *testing.T) (*node.Node, []*types.Block) {
 	// Generate test chain.
-	genesis, blocks := generateTestChain()
+	genesis, blocks, err := generateTestChain()
+	assert.NoError(t, err)
 
 	// Start Ethereum service.
 	var ethservice *eth.Ethereum
@@ -192,7 +194,7 @@ func newTestBackend(t *testing.T) (*node.Node, []*types.Block) {
 	return n, blocks
 }
 
-func generateTestChain() (*core.Genesis, []*types.Block) {
+func generateTestChain() (*core.Genesis, []*types.Block, error) {
 	db := rawdb.NewMemoryDatabase()
 	config := params.AllEthashProtocolChanges
 	genesis := &core.Genesis{
@@ -205,11 +207,15 @@ func generateTestChain() (*core.Genesis, []*types.Block) {
 		g.OffsetTime(5)
 		g.SetExtra([]byte("test"))
 	}
-	gblock := genesis.ToBlock(db)
+	gblock, err := genesis.ToBlock(db)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	engine := ethash.NewFaker()
 	blocks, _ := core.GenerateChain(config, gblock, engine, db, 1, generate)
 	blocks = append([]*types.Block{gblock}, blocks...)
-	return genesis, blocks
+	return genesis, blocks, nil
 }
 
 func TestHeader(t *testing.T) {

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -169,7 +169,10 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config) (*stat
 		return nil, common.Hash{}, UnsupportedForkError{subtest.Fork}
 	}
 	vmconfig.ExtraEips = eips
-	block := t.genesis(config).ToBlock(nil)
+	block, err := t.genesis(config).ToBlock(nil)
+	if err != nil {
+		return nil, common.Hash{}, err
+	}
 	statedb := MakePreState(rawdb.NewMemoryDatabase(), t.json.Pre)
 
 	post := t.json.Post[subtest.Fork][subtest.Index]


### PR DESCRIPTION
The `Committee` field in the genesis file was a duplication of the information stored in the Users field.

This pull request removes it and instead derives the committee from the users field at the point it is needed.