### PR TITLE
Hardcode autonity contract address

### DIFF
--- a/common/acdefault/default.go
+++ b/common/acdefault/default.go
@@ -5,11 +5,6 @@ import (
 	"github.com/clearmatics/autonity/common/acdefault/generated"
 )
 
-func Deployer() common.Address {
-	// "0x0000000000000000000000000000000000000000"
-	return common.Address{}
-}
-
 func Governance() common.Address {
 	return common.HexToAddress("0x1336000000000000000000000000000000000000")
 }

--- a/consensus/tendermint/backend/api.go
+++ b/consensus/tendermint/backend/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/clearmatics/autonity/common"
 	"github.com/clearmatics/autonity/consensus"
 	"github.com/clearmatics/autonity/consensus/tendermint/core"
+	"github.com/clearmatics/autonity/contracts/autonity"
 	"github.com/clearmatics/autonity/core/types"
 	"github.com/clearmatics/autonity/rpc"
 )
@@ -54,7 +55,7 @@ func (api *API) GetCommitteeAtHash(hash common.Hash) (types.Committee, error) {
 
 // Get Autonity contract address
 func (api *API) GetContractAddress() common.Address {
-	return api.tendermint.GetContractAddress()
+	return autonity.ContractAddress
 }
 
 // Get Autonity contract ABI

--- a/consensus/tendermint/backend/api_test.go
+++ b/consensus/tendermint/backend/api_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/clearmatics/autonity/consensus"
 	"github.com/clearmatics/autonity/consensus/tendermint/committee"
 	"github.com/clearmatics/autonity/consensus/tendermint/core"
+	"github.com/clearmatics/autonity/contracts/autonity"
 	"github.com/clearmatics/autonity/core/types"
 	"github.com/clearmatics/autonity/rpc"
 )
@@ -131,18 +132,15 @@ func TestAPIGetContractAddress(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	want := common.HexToAddress("0x0123456789")
-
 	backend := core.NewMockBackend(ctrl)
-	backend.EXPECT().GetContractAddress().Return(want)
 
 	API := &API{
 		tendermint: backend,
 	}
 
 	got := API.GetContractAddress()
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v, got %v", want, got)
+	if !reflect.DeepEqual(got, autonity.ContractAddress) {
+		t.Fatalf("want %v, got %v", autonity.ContractAddress, got)
 	}
 }
 

--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -38,8 +38,8 @@ import (
 	"github.com/clearmatics/autonity/event"
 	"github.com/clearmatics/autonity/log"
 	"github.com/clearmatics/autonity/params"
-	"github.com/hashicorp/golang-lru"
-	"github.com/zfjagann/golang-ring"
+	lru "github.com/hashicorp/golang-lru"
+	ring "github.com/zfjagann/golang-ring"
 )
 
 const (
@@ -127,9 +127,8 @@ type Backend struct {
 	recentMessages *lru.ARCCache // the cache of peer's messages
 	knownMessages  *lru.ARCCache // the cache of self messages
 
-	autonityContractAddress common.Address // Ethereum address of the white list contract
-	contractsMu             sync.RWMutex
-	vmConfig                *vm.Config
+	contractsMu sync.RWMutex
+	vmConfig    *vm.Config
 }
 
 // Address implements tendermint.Backend.Address
@@ -420,10 +419,6 @@ func (sb *Backend) HasBadProposal(hash common.Hash) bool {
 		return false
 	}
 	return sb.hasBadBlock(hash)
-}
-
-func (sb *Backend) GetContractAddress() common.Address {
-	return sb.blockchain.GetAutonityContract().Address()
 }
 
 func (sb *Backend) GetContractABI() string {

--- a/consensus/tendermint/backend/backend_test.go
+++ b/consensus/tendermint/backend/backend_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/clearmatics/autonity/common/acdefault"
 	"math"
 	"math/big"
 	"reflect"
@@ -544,23 +543,6 @@ func TestBackendLastCommittedProposal(t *testing.T) {
 			t.Fatalf("expected empty block, got %v", bl)
 		}
 	})
-}
-
-func TestBackendGetContractAddress(t *testing.T) {
-	chain, engine := newBlockChain(1)
-	block, err := makeBlock(chain, engine, chain.Genesis())
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = chain.InsertChain(types.Blocks{block})
-	if err != nil {
-		t.Fatal(err)
-	}
-	contractAddress := engine.GetContractAddress()
-	expectedAddress := crypto.CreateAddress(acdefault.Deployer(), 0)
-	if !bytes.Equal(contractAddress.Bytes(), expectedAddress.Bytes()) {
-		t.Fatalf("unexpected returned address")
-	}
 }
 
 // Test get contract ABI, it should have the default abi before contract upgrade.

--- a/consensus/tendermint/backend/engine.go
+++ b/consensus/tendermint/backend/engine.go
@@ -20,10 +20,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/clearmatics/autonity/common/acdefault"
-	"github.com/clearmatics/autonity/consensus/tendermint/committee"
 	"math/big"
 	"time"
+
+	"github.com/clearmatics/autonity/consensus/tendermint/committee"
 
 	"github.com/clearmatics/autonity/common"
 	"github.com/clearmatics/autonity/common/hexutil"
@@ -33,7 +33,6 @@ import (
 	"github.com/clearmatics/autonity/core"
 	"github.com/clearmatics/autonity/core/state"
 	"github.com/clearmatics/autonity/core/types"
-	"github.com/clearmatics/autonity/crypto"
 	"github.com/clearmatics/autonity/rpc"
 )
 
@@ -365,16 +364,11 @@ func (sb *Backend) AutonityContractFinalize(header *types.Header, chain consensu
 	defer sb.contractsMu.Unlock()
 
 	if header.Number.Int64() == 1 {
-		contractAddress, err := sb.blockchain.GetAutonityContract().DeployAutonityContract(chain, header, state)
+		err := sb.blockchain.GetAutonityContract().DeployAutonityContract(chain, header, state)
 		if err != nil {
 			sb.logger.Error("Deploy autonity contract error", "error", err)
 			return nil, nil, err
 		}
-		sb.autonityContractAddress = contractAddress
-	}
-
-	if sb.autonityContractAddress == (common.Address{}) {
-		sb.autonityContractAddress = crypto.CreateAddress(acdefault.Deployer(), 0)
 	}
 
 	committeeSet, receipt, err := sb.blockchain.GetAutonityContract().FinalizeAndGetCommittee(txs, receipts, header, state)

--- a/consensus/tendermint/core/backend_mock.go
+++ b/consensus/tendermint/core/backend_mock.go
@@ -136,20 +136,6 @@ func (mr *MockBackendMockRecorder) GetContractABI() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContractABI", reflect.TypeOf((*MockBackend)(nil).GetContractABI))
 }
 
-// GetContractAddress mocks base method
-func (m *MockBackend) GetContractAddress() common.Address {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContractAddress")
-	ret0, _ := ret[0].(common.Address)
-	return ret0
-}
-
-// GetContractAddress indicates an expected call of GetContractAddress
-func (mr *MockBackendMockRecorder) GetContractAddress() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContractAddress", reflect.TypeOf((*MockBackend)(nil).GetContractAddress))
-}
-
 // Gossip mocks base method
 func (m *MockBackend) Gossip(ctx context.Context, valSet *committee.Set, payload []byte) {
 	m.ctrl.T.Helper()

--- a/consensus/tendermint/core/core_backend.go
+++ b/consensus/tendermint/core/core_backend.go
@@ -29,8 +29,6 @@ type Backend interface {
 
 	GetContractABI() string
 
-	GetContractAddress() common.Address
-
 	// Gossip sends a message to all validators (exclude self)
 	Gossip(ctx context.Context, valSet *committee.Set, payload []byte)
 

--- a/consensus/test/autonity_contract_test.go
+++ b/consensus/test/autonity_contract_test.go
@@ -4,12 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/clearmatics/autonity/common/acdefault"
-	"github.com/clearmatics/autonity/common/graph"
-	"github.com/clearmatics/autonity/common/keygenerator"
-	"github.com/clearmatics/autonity/common/math"
-	"github.com/clearmatics/autonity/log"
-	"github.com/clearmatics/autonity/p2p/enode"
 	"math/big"
 	"net"
 	"strconv"
@@ -17,6 +11,14 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/clearmatics/autonity/common/acdefault"
+	"github.com/clearmatics/autonity/common/graph"
+	"github.com/clearmatics/autonity/common/keygenerator"
+	"github.com/clearmatics/autonity/common/math"
+	"github.com/clearmatics/autonity/contracts/autonity"
+	"github.com/clearmatics/autonity/log"
+	"github.com/clearmatics/autonity/p2p/enode"
 
 	"github.com/clearmatics/autonity/accounts/abi/bind"
 	"github.com/clearmatics/autonity/ethclient"
@@ -39,27 +41,19 @@ func TestCheckFeeRedirectionAndRedistribution(t *testing.T) {
 		prevSTBalance := new(big.Int)
 
 		fBefore := func(block *types.Block, validator *testNode, tCase *testCase, currentTime time.Time) error {
-			addr, err := validator.service.BlockChain().Config().AutonityContractConfig.GetContractAddress()
-			if err != nil {
-				return err
-			}
 			st, _ := validator.service.BlockChain().State()
-			if block.NumberU64() == 1 && st.GetBalance(addr).Uint64() != 0 {
+			if block.NumberU64() == 1 && st.GetBalance(autonity.ContractAddress).Uint64() != 0 {
 				return fmt.Errorf("incorrect balance on the first block")
 			}
 			return nil
 		}
 		fAfter := func(block *types.Block, validator *testNode, tCase *testCase, currentTime time.Time) error {
-			autonityContractAddress, err := validator.service.BlockChain().Config().AutonityContractConfig.GetContractAddress()
-			if err != nil {
-				return err
-			}
 			st, _ := validator.service.BlockChain().State()
 
 			if block.NumberU64() == 1 && prevBlockBalance != 0 {
 				return fmt.Errorf("incorrect balance on the first block")
 			}
-			contractBalance := st.GetBalance(autonityContractAddress)
+			contractBalance := st.GetBalance(autonity.ContractAddress)
 			if block.NumberU64() > 1 && len(block.Transactions()) > 0 && block.NumberU64() <= uint64(tCase.numBlocks) {
 				if contractBalance.Uint64() < prevBlockBalance {
 					return fmt.Errorf("balance must be increased")
@@ -140,27 +134,19 @@ func TestCheckBlockWithSmallFee(t *testing.T) {
 	hookGenerator := func() (hook, hook) {
 		prevBlockBalance := uint64(0)
 		fBefore := func(block *types.Block, validator *testNode, tCase *testCase, currentTime time.Time) error {
-			addr, err := validator.service.BlockChain().Config().AutonityContractConfig.GetContractAddress()
-			if err != nil {
-				t.Fatal(err)
-			}
 			st, _ := validator.service.BlockChain().State()
-			if block.NumberU64() == 1 && st.GetBalance(addr).Uint64() != 0 {
+			if block.NumberU64() == 1 && st.GetBalance(autonity.ContractAddress).Uint64() != 0 {
 				t.Fatal("incorrect balance on the first block")
 			}
 			return nil
 		}
 		fAfter := func(block *types.Block, validator *testNode, tCase *testCase, currentTime time.Time) error {
-			autonityContractAddress, err := validator.service.BlockChain().Config().AutonityContractConfig.GetContractAddress()
-			if err != nil {
-				t.Fatal(err)
-			}
 			st, _ := validator.service.BlockChain().State()
 
 			if block.NumberU64() == 1 && prevBlockBalance != 0 {
 				t.Fatal("incorrect balance on the first block")
 			}
-			contractBalance := st.GetBalance(autonityContractAddress)
+			contractBalance := st.GetBalance(autonity.ContractAddress)
 
 			prevBlockBalance = contractBalance.Uint64()
 			return nil
@@ -323,8 +309,7 @@ func TestRemoveFromValidatorsList(t *testing.T) {
 			auth.GasLimit = uint64(300000) // in units
 			auth.GasPrice = gasPrice
 
-			contractAddress := validator.service.BlockChain().GetAutonityContract().Address()
-			instance, err := NewAutonity(contractAddress, conn)
+			instance, err := NewAutonity(autonity.ContractAddress, conn)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -401,8 +386,7 @@ func TestAddIncorrectStakeholdersToList(t *testing.T) {
 			auth.GasLimit = uint64(300000) // in units
 			auth.GasPrice = gasPrice
 
-			contractAddress := validator.service.BlockChain().GetAutonityContract().Address()
-			instance, err := NewAutonity(contractAddress, conn)
+			instance, err := NewAutonity(autonity.ContractAddress, conn)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -478,8 +462,7 @@ func TestAddStakeholderWithCorruptedEnodeToList(t *testing.T) {
 			auth.GasLimit = uint64(300000) // in units
 			auth.GasPrice = gasPrice
 
-			contractAddress := validator.service.BlockChain().GetAutonityContract().Address()
-			instance, err := NewAutonity(contractAddress, conn)
+			instance, err := NewAutonity(autonity.ContractAddress, conn)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -705,8 +688,7 @@ func upgradeHook(t *testing.T, upgradeBlocks map[uint64]struct{}, operatorAddres
 		auth.GasLimit = uint64(30000000) // in units
 		auth.GasPrice = gasPrice
 
-		contractAddress := validator.service.BlockChain().GetAutonityContract().Address()
-		instance, err := NewAutonity(contractAddress, conn)
+		instance, err := NewAutonity(autonity.ContractAddress, conn)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/contracts/autonity/autonity.go
+++ b/contracts/autonity/autonity.go
@@ -2,9 +2,7 @@ package autonity
 
 import (
 	"errors"
-	"github.com/clearmatics/autonity/common/acdefault"
 	"math/big"
-	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -15,58 +13,60 @@ import (
 	"github.com/clearmatics/autonity/core/state"
 	"github.com/clearmatics/autonity/core/types"
 	"github.com/clearmatics/autonity/core/vm"
+	"github.com/clearmatics/autonity/crypto"
 	"github.com/clearmatics/autonity/log"
-	"github.com/clearmatics/autonity/params"
 )
 
 var ErrAutonityContract = errors.New("could not call Autonity contract")
 var ErrWrongParameter = errors.New("wrong parameter")
+var deployer = common.Address{}
+var ContractAddress = crypto.CreateAddress(deployer, 0)
 
 const ABISPEC = "ABISPEC"
 
-func NewAutonityContract(
-	bc Blockchainer,
-	canTransfer func(db vm.StateDB, addr common.Address, amount *big.Int) bool,
-	transfer func(db vm.StateDB, sender, recipient common.Address, amount *big.Int),
-	GetHashFn func(ref *types.Header, chain ChainContext) func(n uint64) common.Hash,
-) *Contract {
-	return &Contract{
-		bc:          bc,
-		canTransfer: canTransfer,
-		transfer:    transfer,
-		GetHashFn:   GetHashFn,
-	}
+// EVMProvider provides a new evm. This allows us to decouple the contract from *params.ChainConfig which is required to build a new evm.
+type EVMProvider interface {
+	EVM(header *types.Header, origin common.Address, statedb *state.StateDB) *vm.EVM
 }
 
-type ChainContext interface {
-	// Engine retrieves the chain's consensus engine.
-	Engine() consensus.Engine
+func NewAutonityContract(
+	bc Blockchainer,
+	operator common.Address,
+	minGasPrice uint64,
+	ABI string,
+	evmProvider EVMProvider,
+) (*Contract, error) {
 
-	// GetHeader returns the hash corresponding to their hash.
-	GetHeader(common.Hash, uint64) *types.Header
+	contractABI, err := abi.JSON(strings.NewReader(ABI))
+	if err != nil {
+		return nil, err
+	}
+	return &Contract{
+		stringContractABI:  ABI,
+		contractABI:        &contractABI,
+		operator:           operator,
+		initialMinGasPrice: minGasPrice,
+		bc:                 bc,
+		evmProvider:        evmProvider,
+	}, nil
 }
 
 type Blockchainer interface {
-	ChainContext
-	GetVMConfig() *vm.Config
-	Config() *params.ChainConfig
-
 	UpdateEnodeWhitelist(newWhitelist *types.Nodes)
 	ReadEnodeWhitelist() *types.Nodes
 
 	PutKeyValue(key []byte, value []byte) error
-	GetKeyValue(key []byte) ([]byte, error)
 }
 
 type Contract struct {
-	address     common.Address
-	contractABI *abi.ABI
-	bc          Blockchainer
-	metrics     EconomicMetrics
+	evmProvider        EVMProvider
+	operator           common.Address
+	initialMinGasPrice uint64
+	contractABI        *abi.ABI
+	stringContractABI  string
+	bc                 Blockchainer
+	metrics            EconomicMetrics
 
-	canTransfer func(db vm.StateDB, addr common.Address, amount *big.Int) bool
-	transfer    func(db vm.StateDB, sender, recipient common.Address, amount *big.Int)
-	GetHashFn   func(ref *types.Header, chain ChainContext) func(n uint64) common.Hash
 	sync.RWMutex
 }
 
@@ -77,10 +77,8 @@ func (ac *Contract) MeasureMetricsOfNetworkEconomic(header *types.Header, stateD
 	}
 
 	// prepare abi and evm context
-	deployer := acdefault.Deployer()
-	sender := vm.AccountRef(deployer)
 	gas := uint64(0xFFFFFFFF)
-	evm := ac.getEVM(header, deployer, stateDB)
+	evm := ac.evmProvider.EVM(header, deployer, stateDB)
 
 	ABI, err := ac.abi()
 	if err != nil {
@@ -96,7 +94,7 @@ func (ac *Contract) MeasureMetricsOfNetworkEconomic(header *types.Header, stateD
 
 	// call evm.
 	value := new(big.Int).SetUint64(0x00)
-	ret, _, vmerr := evm.Call(sender, ac.Address(), input, gas, value)
+	ret, _, vmerr := evm.Call(vm.AccountRef(deployer), ContractAddress, input, gas, value)
 	if vmerr != nil {
 		log.Warn("Error Autonity Contract dumpNetworkEconomics", err, vmerr)
 		return
@@ -114,7 +112,7 @@ func (ac *Contract) MeasureMetricsOfNetworkEconomic(header *types.Header, stateD
 		return
 	}
 
-	ac.metrics.SubmitEconomicMetrics(&v, stateDB, header.Number.Uint64(), ac.bc.Config().AutonityContractConfig.Operator)
+	ac.metrics.SubmitEconomicMetrics(&v, stateDB, header.Number.Uint64(), ac.operator)
 }
 
 func (ac *Contract) GetCommittee(chain consensus.ChainReader, header *types.Header, statedb *state.StateDB) (types.Committee, error) {
@@ -162,7 +160,7 @@ func (ac *Contract) GetWhitelist(block *types.Block, db *state.StateDB) (*types.
 
 func (ac *Contract) GetMinimumGasPrice(block *types.Block, db *state.StateDB) (uint64, error) {
 	if block.Number().Uint64() <= 1 {
-		return ac.bc.Config().AutonityContractConfig.MinGasPrice, nil
+		return ac.initialMinGasPrice, nil
 	}
 
 	return ac.callGetMinimumGasPrice(db, block.Header())
@@ -186,7 +184,7 @@ func (ac *Contract) FinalizeAndGetCommittee(transactions types.Transactions, rec
 	}
 
 	log.Info("ApplyFinalize",
-		"balance", statedb.GetBalance(ac.Address()),
+		"balance", statedb.GetBalance(ContractAddress),
 		"block", header.Number.Uint64(),
 		"gas", blockGas.Uint64())
 
@@ -237,7 +235,7 @@ func (ac *Contract) performContractUpgrade(statedb *state.StateDB, header *types
 	snapshot := statedb.Snapshot()
 
 	// Create account will delete previous the AC stateobject and carry over the balance
-	statedb.CreateAccount(ac.Address())
+	statedb.CreateAccount(ContractAddress)
 
 	if err := ac.UpdateAutonityContract(header, statedb, bytecode, newAbi, stateBefore); err != nil {
 		statedb.RevertToSnapshot(snapshot)
@@ -259,35 +257,7 @@ func (ac *Contract) performContractUpgrade(statedb *state.StateDB, header *types
 	return nil
 }
 
-func (ac *Contract) Address() common.Address {
-	if reflect.DeepEqual(ac.address, common.Address{}) {
-		addr, err := ac.bc.Config().AutonityContractConfig.GetContractAddress()
-		if err != nil {
-			log.Error("Cant get contract address", "err", err)
-		}
-		return addr
-	}
-	return ac.address
-}
-
 func (ac *Contract) abi() (*abi.ABI, error) {
-	ac.Lock()
-	defer ac.Unlock()
-	if ac.contractABI != nil {
-		return ac.contractABI, nil
-	}
-	var JSONString = ac.bc.Config().AutonityContractConfig.ABI
-
-	bytes, err := ac.bc.GetKeyValue([]byte(ABISPEC))
-	if err == nil || bytes != nil {
-		JSONString = string(bytes)
-	}
-
-	ABI, err := abi.JSON(strings.NewReader(JSONString))
-	if err != nil {
-		return nil, err
-	}
-	ac.contractABI = &ABI
 	return ac.contractABI, nil
 }
 
@@ -304,18 +274,5 @@ func (ac *Contract) upgradeAbiCache(newAbi string) error {
 }
 
 func (ac *Contract) GetContractABI() string {
-	ac.Lock()
-	defer ac.Unlock()
-
-	var JSONString = ac.bc.Config().AutonityContractConfig.ABI
-	bytes, err := ac.bc.GetKeyValue([]byte(ABISPEC))
-	if err == nil || bytes != nil {
-		JSONString = string(bytes)
-	}
-
-	if err != nil {
-		log.Warn("can't get the contract ABI", "err", err)
-	}
-
-	return JSONString
+	return ac.stringContractABI
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -254,13 +254,30 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 		return nil, err
 	}
 	if chainConfig.Tendermint != nil {
+
 		if chainConfig.AutonityContractConfig == nil {
 			return nil, errors.New("we need autonity contract specified for tendermint or istanbul consensus")
 		}
 
-		bc.autonityContract = autonity.NewAutonityContract(bc, CanTransfer, Transfer, func(ref *types.Header, chain autonity.ChainContext) func(n uint64) common.Hash {
-			return GetHashFn(ref, chain)
-		})
+		acConfig := bc.Config().AutonityContractConfig
+
+		var JSONString = acConfig.ABI
+		bytes, err := bc.GetKeyValue([]byte(autonity.ABISPEC))
+		if err == nil || bytes != nil {
+			JSONString = string(bytes)
+		}
+		contract, err := autonity.NewAutonityContract(
+			bc,
+			acConfig.Operator,
+			acConfig.MinGasPrice,
+			JSONString,
+			&defaultEVMProvider{bc},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		bc.autonityContract = contract
 		bc.processor.SetAutonityContract(bc.autonityContract)
 	}
 	// The first thing the node will do is reconstruct the verification data for

--- a/core/default_evm_provider.go
+++ b/core/default_evm_provider.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"math/big"
+
+	"github.com/clearmatics/autonity/common"
+	"github.com/clearmatics/autonity/core/state"
+	"github.com/clearmatics/autonity/core/types"
+	"github.com/clearmatics/autonity/core/vm"
+)
+
+// defaultEVMProvider implements autonity.EVMProvider
+type defaultEVMProvider struct {
+	bc *BlockChain
+}
+
+func (p *defaultEVMProvider) EVM(header *types.Header, origin common.Address, statedb *state.StateDB) *vm.EVM {
+	coinbase, _ := types.Ecrecover(header)
+	evmContext := vm.Context{
+		CanTransfer: CanTransfer,
+		Transfer:    Transfer,
+		GetHash:     GetHashFn(header, p.bc),
+		Origin:      origin,
+		Coinbase:    coinbase,
+		BlockNumber: header.Number,
+		Time:        new(big.Int).SetUint64(header.Time),
+		GasLimit:    header.GasLimit,
+		Difficulty:  header.Difficulty,
+		GasPrice:    new(big.Int).SetUint64(0x0),
+	}
+	vmConfig := *p.bc.GetVMConfig()
+	evm := vm.NewEVM(evmContext, statedb, p.bc.Config(), vmConfig)
+	return evm
+}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 
 	"github.com/clearmatics/autonity/common"
+	"github.com/clearmatics/autonity/contracts/autonity"
 	"github.com/clearmatics/autonity/core/vm"
 	"github.com/clearmatics/autonity/log"
 	"github.com/clearmatics/autonity/params"
@@ -230,11 +231,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 	address := st.evm.Coinbase
 
 	if st.evm.ChainConfig().AutonityContractConfig != nil && st.evm.ChainConfig().Tendermint != nil {
-		addr, innerErr := st.evm.ChainConfig().AutonityContractConfig.GetContractAddress()
-		if innerErr != nil {
-			return nil, 0, true, innerErr
-		}
-		address = addr
+		address = autonity.ContractAddress
 	}
 	st.state.AddBalance(address, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
 

--- a/params/autonity_contract.go
+++ b/params/autonity_contract.go
@@ -3,12 +3,12 @@ package params
 import (
 	"errors"
 	"fmt"
+	"reflect"
+
 	"github.com/clearmatics/autonity/common"
 	"github.com/clearmatics/autonity/common/acdefault"
-	"github.com/clearmatics/autonity/crypto"
 	"github.com/clearmatics/autonity/log"
 	"github.com/clearmatics/autonity/p2p/enode"
-	"reflect"
 )
 
 const (
@@ -97,10 +97,6 @@ func (ac *AutonityContractGenesis) Validate() error {
 	}
 
 	return nil
-}
-
-func (ac *AutonityContractGenesis) GetContractAddress() (common.Address, error) {
-	return crypto.CreateAddress(acdefault.Deployer(), 0), nil
 }
 
 //User - is used to put predefined accounts to genesis


### PR DESCRIPTION
This is an extension to #552 

Since the deployer address is hardcoded we can also hardcode the
autonity contract address.

During the process of trying to hardcode the contract address I had the need to create the EVMProvider, it is now not necessary and could be removed, but I think it is a good change in its own right since it decouples the autonity contract from `params.ChainConfig`. The reason decoupling from  `params.ChainConfig` is good is that `params.ChainConfig` has a lot more stuff in it than is needed by the autonity contract and providing more than is needed to objects increases the chance that you end up with a circular dependency which is the problem I was initially facing.