### PR TITLE
Fix tendermint/backend.Backend.committee function

### DIFF
--- a/consensus/tendermint/backend/engine.go
+++ b/consensus/tendermint/backend/engine.go
@@ -20,9 +20,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/clearmatics/autonity/consensus/tendermint/committee"
 	"math/big"
 	"time"
+
+	"github.com/clearmatics/autonity/consensus/tendermint/committee"
 
 	"github.com/clearmatics/autonity/common"
 	"github.com/clearmatics/autonity/common/hexutil"
@@ -581,7 +582,7 @@ func (sb *Backend) committee(header *types.Header, parents []*types.Header, chai
 		if err != nil {
 			return nil, err
 		}
-		return committee.NewSet(header.Committee, lastMiner)
+		return committee.NewSet(parent.Committee, lastMiner)
 	} else {
 		return sb.savedCommittee(header.Number.Uint64(), chain)
 	}


### PR DESCRIPTION
The committee for each block is defined in the parent header, the
committee function was using the committee defined in the current header
as the committee for the current block. This change ensures that the
committee function correctly uses the committee defined in the parent
header as the committee for the current block.