### PR TITLE
Ensure generated genesis has a difficulty of 1

### DIFF
--- a/cmd/gengen/new_genesis.go
+++ b/cmd/gengen/new_genesis.go
@@ -146,8 +146,12 @@ func newGenesis(minGasPrice uint64, userStrings []string, userKeys []string) (*c
 		// unmarshals to an empty slice.
 		ExtraData: []byte{},
 
-		GasLimit:   math.MaxUint64,
-		Difficulty: big.NewInt(0),
+		GasLimit: math.MaxUint64,
+
+		// Autonity relies on the difficulty always being 1 so that we can
+		// compare chain length by comparing total difficulty during peer
+		// connection handshake.
+		Difficulty: big.NewInt(1),
 
 		Alloc: genesisAlloc,
 

--- a/docs/source/genesis_file.rst
+++ b/docs/source/genesis_file.rst
@@ -283,9 +283,12 @@ please note that comments are not permitted in valid JSON_.
 
      "gasLimit": "0x0",
 
-     // difficulty is unused by Autonity but is required to be part of the block
-     // header for the virtual machine to function correctly. The gengen tool
-     // leaves this unset.
+    // difficulty is not a concept that makes sense in BFT consensus protocols.
+    // Despite this Autonity still makes use of difficulty by hardcoding it to 1,
+    // which allows us to use the total difficulty field exchanged during peer
+    // connection handshake as a means to decide which peer is ahead. This information
+    // is used to determine whether or not a peer should be allowed to connect to the
+    // network. The gengen tool sets this to 1.
 
      "difficulty": "0x0",
 


### PR DESCRIPTION
In #515 although I enforced that difficulty must be 1 when storing the genesis block in the database, I forgot to update the genesis generation to generate genesis files with a difficulty of 1. I also neglected to update the genesis file documentation for the difficulty field. This PR fixes that.