### PR TITLE
Remove the HeaderGetter interface

### DIFF
--- a/contracts/autonity/autonity.go
+++ b/contracts/autonity/autonity.go
@@ -2,11 +2,12 @@ package autonity
 
 import (
 	"errors"
-	"github.com/clearmatics/autonity/params"
 	"math/big"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/clearmatics/autonity/params"
 
 	"github.com/clearmatics/autonity/accounts/abi"
 	"github.com/clearmatics/autonity/common"
@@ -29,13 +30,7 @@ type EVMProvider interface {
 	EVM(header *types.Header, origin common.Address, statedb *state.StateDB) *vm.EVM
 }
 
-type ChainContext interface {
-	// GetHeader returns the hash corresponding to their hash.
-	GetHeader(common.Hash, uint64) *types.Header
-}
-
 type Blockchainer interface {
-	ChainContext
 	UpdateEnodeWhitelist(newWhitelist *types.Nodes)
 	ReadEnodeWhitelist() *types.Nodes
 

--- a/core/evm.go
+++ b/core/evm.go
@@ -25,16 +25,11 @@ import (
 	"github.com/clearmatics/autonity/core/vm"
 )
 
-// This interface was introduced to avoid cyclic imports with the autonity package.
-type HeaderGetter interface {
-	// GetHeader returns the hash corresponding to their hash.
-	GetHeader(common.Hash, uint64) *types.Header
-}
-
 // ChainContext supports retrieving headers and consensus parameters from the
 // current blockchain to be used during transaction processing.
 type ChainContext interface {
-	HeaderGetter
+	// GetHeader returns the hash corresponding to their hash.
+	GetHeader(common.Hash, uint64) *types.Header
 	// Engine retrieves the chain's consensus engine.
 	Engine() consensus.Engine
 }
@@ -63,7 +58,7 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author
 }
 
 // GetHashFn returns a GetHashFunc which retrieves header hashes by number
-func GetHashFn(ref *types.Header, chain HeaderGetter) func(n uint64) common.Hash {
+func GetHashFn(ref *types.Header, chain ChainContext) func(n uint64) common.Hash {
 	// Cache will initially contain [refHash.parent],
 	// Then fill up with [refHash.p, refHash.pp, refHash.ppp, ...]
 	var cache []common.Hash


### PR DESCRIPTION
Changes to the autonity contract in "Hardcode deployer address (#552)"
meant that this interface was no longer required.