### PR TITLE
Hide the config bytecode and abi fields from users

### DIFF
--- a/docs/source/genesis_file.rst
+++ b/docs/source/genesis_file.rst
@@ -142,24 +142,6 @@ please note that comments are not permitted in valid JSON_.
 
        "autonityContract": {
 
-         // The bytecode of the Autonity contract, if left unset the Autonity
-         // client will use the embedded contract bytecode. It is advisable to
-         // leave this blank since the embedded contract bytecode should be in
-         // sync with the Autonity client code. The gengen tool leaves this blank.
-         // If this is set then the abi field should be set with an ABI generated
-         // from the same contract source.
-
-         "bytecode": "",
-
-         // The ABI (Application Binary Interface) of the Autonity contract, if
-         // left unset the Autonity client will use the embedded contract ABI. It
-         // is advisable to leave this blank since the embedded contract ABI
-         // should be in sync with the Autonity client code. The gengen tool
-         // leaves this blank. If this is set then the bytecode field should be
-         // set with bytecode generated from the same contract source.
-
-         "abi": "",
-
          // minGasPrice sets the minimum gas price for submitting transactions to
          // the network. Transactions submitted with a gas price lower than this
          // will be ignored. This is what will determine the minimum cost for

--- a/params/autonity_contract.go
+++ b/params/autonity_contract.go
@@ -3,8 +3,9 @@ package params
 import (
 	"errors"
 	"fmt"
-	"github.com/clearmatics/autonity/crypto"
 	"reflect"
+
+	"github.com/clearmatics/autonity/crypto"
 
 	"github.com/clearmatics/autonity/common"
 	"github.com/clearmatics/autonity/common/acdefault"
@@ -44,9 +45,9 @@ func (ut UserType) GetID() int {
 type AutonityContractGenesis struct {
 	// Bytecode of validators contract
 	// would like this type to be []byte but the unmarshalling is not working
-	Bytecode string `json:"bytecode" toml:",omitempty"`
+	Bytecode string `json:"bytecode,omitempty" toml:",omitempty"`
 	// Json ABI of the contract
-	ABI         string         `json:"abi" toml:",omitempty"`
+	ABI         string         `json:"abi,omitempty" toml:",omitempty"`
 	MinGasPrice uint64         `json:"minGasPrice" toml:",omitempty"`
 	Operator    common.Address `json:"operator" toml:",omitempty"`
 	Users       []User         `json:"users" toml:",omitempty"`


### PR DESCRIPTION
These fields are part of the Autonity contract config but in order to
correctly set them users would have to have, a very in depth
understanding of how Autonity is working. Until we can provide the
support required for users to know enough to set these fields correctly,
we hide them, by removing documentation for them and ensuring they do
not appear in serialised genesis files.

Closes #513