### PR TITLE
Blockperiod fixes

### DIFF
--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -86,7 +86,7 @@ func New(config *tendermintConfig.Config, privateKey *ecdsa.PrivateKey, db ethdb
 	}
 
 	backend.pendingMessages.SetCapacity(ringCapacity)
-	backend.core = tendermintCore.New(backend, config.ProposerPolicy)
+	backend.core = tendermintCore.New(backend, config)
 	return backend
 }
 

--- a/consensus/tendermint/config/config.go
+++ b/consensus/tendermint/config/config.go
@@ -38,3 +38,10 @@ func DefaultConfig() *Config {
 		ProposerPolicy: WeightedRandomSampling,
 	}
 }
+
+func RoundRobinConfig() *Config {
+	return &Config{
+		BlockPeriod:    1,
+		ProposerPolicy: RoundRobin,
+	}
+}

--- a/consensus/tendermint/core/handler_test.go
+++ b/consensus/tendermint/core/handler_test.go
@@ -172,7 +172,7 @@ func TestCoreStopDoesntPanic(t *testing.T) {
 
 	backendMock.EXPECT().Subscribe(gomock.Any()).Return(sub).MaxTimes(5)
 
-	c := New(backendMock, config.RoundRobin)
+	c := New(backendMock, config.DefaultConfig())
 	_, c.cancel = context.WithCancel(context.Background())
 	c.subscribeEvents()
 	c.stopped <- struct{}{}

--- a/consensus/tendermint/core/precommit.go
+++ b/consensus/tendermint/core/precommit.go
@@ -126,7 +126,7 @@ func (c *core) handlePrecommit(ctx context.Context, msg *Message) error {
 
 		// Line 47 in Algorithm 1 of The latest gossip on BFT consensus
 	} else if !c.precommitTimeout.timerStarted() && c.curRoundMessages.PrecommitsTotalPower() >= c.committeeSet().Quorum() {
-		timeoutDuration := timeoutPrecommit(c.Round())
+		timeoutDuration := c.timeoutPrecommit(c.Round())
 		c.precommitTimeout.scheduleTimeout(timeoutDuration, c.Round(), c.Height(), c.onTimeoutPrecommit)
 		c.logger.Debug("Scheduled Precommit Timeout", "Timeout Duration", timeoutDuration)
 	}

--- a/consensus/tendermint/core/prevote.go
+++ b/consensus/tendermint/core/prevote.go
@@ -116,7 +116,7 @@ func (c *core) handlePrevote(ctx context.Context, msg *Message) error {
 
 			// Line 34 in Algorithm 1 of The latest gossip on BFT consensus
 		} else if c.step == prevote && !c.prevoteTimeout.timerStarted() && !c.sentPrecommit && c.curRoundMessages.PrevotesTotalPower() >= c.committeeSet().Quorum() {
-			timeoutDuration := timeoutPrevote(c.Round())
+			timeoutDuration := c.timeoutPrevote(c.Round())
 			c.prevoteTimeout.scheduleTimeout(timeoutDuration, c.Round(), c.Height(), c.onTimeoutPrevote)
 			c.logger.Debug("Scheduled Prevote Timeout", "Timeout Duration", timeoutDuration)
 		}

--- a/consensus/tendermint/core/prevote_test.go
+++ b/consensus/tendermint/core/prevote_test.go
@@ -352,7 +352,7 @@ func TestHandlePrevote(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().AnyTimes().Return(addr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.curRoundMessages = curRoundMessages
 		c.height = big.NewInt(2)
 		c.round = 1

--- a/consensus/tendermint/core/timeout.go
+++ b/consensus/tendermint/core/timeout.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	initialProposeTimeout   = 3000 * time.Millisecond
+	initialProposeTimeout   = 2000 * time.Millisecond
 	proposeTimeoutDelta     = 500 * time.Millisecond
 	initialPrevoteTimeout   = 1000 * time.Millisecond
 	prevoteTimeoutDelta     = 500 * time.Millisecond
@@ -108,15 +108,15 @@ func (t *timeout) reset(s Step) {
 func (c *core) measureMetricsOnTimeOut(step uint64, r int64) {
 	switch step {
 	case msgProposal:
-		duration := timeoutPropose(r)
+		duration := c.timeoutPropose(r)
 		tendermintProposeTimer.Update(duration)
 		return
 	case msgPrevote:
-		duration := timeoutPrevote(r)
+		duration := c.timeoutPrevote(r)
 		tendermintPrevoteTimer.Update(duration)
 		return
 	case msgPrecommit:
-		duration := timeoutPrecommit(r)
+		duration := c.timeoutPrecommit(r)
 		tendermintPrecommitTimer.Update(duration)
 		return
 	}
@@ -183,15 +183,15 @@ func (c *core) handleTimeoutPrecommit(ctx context.Context, msg TimeoutEvent) {
 
 /////////////// Calculate Timeout Duration Functions ///////////////
 // The timeout may need to be changed depending on the Step
-func timeoutPropose(round int64) time.Duration {
-	return initialProposeTimeout + time.Duration(round)*proposeTimeoutDelta
+func (c *core) timeoutPropose(round int64) time.Duration {
+	return initialProposeTimeout + time.Duration(c.blockPeriod)*time.Second + time.Duration(round)*proposeTimeoutDelta
 }
 
-func timeoutPrevote(round int64) time.Duration {
+func (c *core) timeoutPrevote(round int64) time.Duration {
 	return initialPrevoteTimeout + time.Duration(round)*prevoteTimeoutDelta
 }
 
-func timeoutPrecommit(round int64) time.Duration {
+func (c *core) timeoutPrecommit(round int64) time.Duration {
 	return initialPrecommitTimeout + time.Duration(round)*precommitTimeoutDelta
 }
 

--- a/consensus/tendermint/core/upon_condition_test.go
+++ b/consensus/tendermint/core/upon_condition_test.go
@@ -77,7 +77,7 @@ func TestStartRoundVariables(t *testing.T) {
 		backendMock.EXPECT().Address().Return(clientAddress)
 		backendMock.EXPECT().LastCommittedProposal().Return(prevBlock, clientAddress)
 
-		core := New(backendMock, config.RoundRobin)
+		core := New(backendMock, config.RoundRobinConfig())
 
 		overrideDefaultCoreValues(core)
 		core.startRound(context.Background(), currentRound)
@@ -96,7 +96,7 @@ func TestStartRoundVariables(t *testing.T) {
 		backendMock.EXPECT().Address().Return(clientAddress)
 		backendMock.EXPECT().LastCommittedProposal().Return(prevBlock, clientAddress).MaxTimes(2)
 
-		core := New(backendMock, config.RoundRobin)
+		core := New(backendMock, config.RoundRobinConfig())
 		overrideDefaultCoreValues(core)
 		core.startRound(context.Background(), currentRound)
 
@@ -156,7 +156,7 @@ func TestStartRound(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		core := New(backendMock, config.RoundRobin)
+		core := New(backendMock, config.RoundRobinConfig())
 		// We assume that round 0 can only happen when we move to a new height, therefore, height is
 		// incremented by 1 in start round when round = 0, and the committee set is updated. However, in test case where
 		// round is more than 0, then we need to explicitly update the committee set and height.
@@ -195,7 +195,7 @@ func TestStartRound(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		core := New(backendMock, config.RoundRobin)
+		core := New(backendMock, config.DefaultConfig())
 		core.committee = committeeSet
 		core.height = proposalHeight
 		core.validRound = validR
@@ -225,7 +225,7 @@ func TestStartRound(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		core := New(backendMock, config.RoundRobin)
+		core := New(backendMock, config.DefaultConfig())
 
 		if currentRound > 0 {
 			core.committee = committeeSet
@@ -249,7 +249,7 @@ func TestStartRound(t *testing.T) {
 
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setCommitteeSet(committeeSet)
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
@@ -271,7 +271,7 @@ func TestStartRound(t *testing.T) {
 
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setCommitteeSet(committeeSet)
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
@@ -302,7 +302,7 @@ func TestNewProposal(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(propose)
@@ -337,7 +337,7 @@ func TestNewProposal(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		// if lockedRround = - 1 then lockedValue = nil
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
@@ -369,7 +369,7 @@ func TestNewProposal(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(propose)
@@ -405,7 +405,7 @@ func TestNewProposal(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(propose)
@@ -453,7 +453,7 @@ func TestOldProposal(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(propose)
@@ -492,7 +492,7 @@ func TestOldProposal(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(propose)
@@ -532,7 +532,7 @@ func TestOldProposal(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(propose)
@@ -579,7 +579,7 @@ func TestPrevoteTimeout(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(prevote)
@@ -607,7 +607,7 @@ func TestPrevoteTimeout(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(prevote)
@@ -640,7 +640,7 @@ func TestPrevoteTimeout(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(prevote)
@@ -665,7 +665,7 @@ func TestPrevoteTimeout(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(prevote)
@@ -704,7 +704,7 @@ func TestQuorumPrevote(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(currentStep)
@@ -753,7 +753,7 @@ func TestQuorumPrevote(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(currentStep)
@@ -821,7 +821,7 @@ func TestQuorumPrevoteNil(t *testing.T) {
 	backendMock := NewMockBackend(ctrl)
 	backendMock.EXPECT().Address().Return(clientAddr)
 
-	c := New(backendMock, config.RoundRobin)
+	c := New(backendMock, config.DefaultConfig())
 	c.setHeight(currentHeight)
 	c.setRound(currentRound)
 	c.setStep(prevote)
@@ -858,7 +858,7 @@ func TestPrecommitTimeout(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		//TODO: this should be changed to Step(rand.Intn(3)) to make sure precommit timeout can be started from any step
@@ -887,7 +887,7 @@ func TestPrecommitTimeout(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		//TODO: this should be changed to Step(rand.Intn(3)) to make sure precommit timeout can be started from any step
@@ -921,7 +921,7 @@ func TestPrecommitTimeout(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		//TODO: this should be changed to Step(rand.Intn(3)) to make sure precommit timeout can be started from any step
@@ -949,7 +949,7 @@ func TestPrecommitTimeout(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		//TODO: this should be changed to Step(rand.Intn(3)) to make sure precommit timeout can be started from any step
@@ -986,7 +986,7 @@ func TestQuorumPrecommit(t *testing.T) {
 	backendMock := NewMockBackend(ctrl)
 	backendMock.EXPECT().Address().Return(clientAddr)
 
-	c := New(backendMock, config.RoundRobin)
+	c := New(backendMock, config.RoundRobinConfig())
 	c.setHeight(currentHeight)
 	c.setRound(currentRound)
 	c.setStep(precommit)
@@ -1057,7 +1057,7 @@ func TestFutureRoundChange(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(currentStep)
@@ -1091,7 +1091,7 @@ func TestFutureRoundChange(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(clientAddr)
 
-		c := New(backendMock, config.RoundRobin)
+		c := New(backendMock, config.DefaultConfig())
 		c.setHeight(currentHeight)
 		c.setRound(currentRound)
 		c.setStep(currentStep)
@@ -1148,7 +1148,7 @@ func TestHandleMessage(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(key1PubAddr)
 
-		core := New(backendMock, config.RoundRobin)
+		core := New(backendMock, config.DefaultConfig())
 		core.setCommitteeSet(committeeSet)
 		core.lastHeader = prevBlock.Header()
 		err = core.handleMsg(context.Background(), msgRlpWithSig)
@@ -1176,7 +1176,7 @@ func TestHandleMessage(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(key1PubAddr)
 
-		core := New(backendMock, config.RoundRobin)
+		core := New(backendMock, config.DefaultConfig())
 		core.setCommitteeSet(committeeSet)
 		core.lastHeader = prevBlock.Header()
 		err = core.handleMsg(context.Background(), msgRlpWithSig)
@@ -1200,7 +1200,7 @@ func TestHandleMessage(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Address().Return(key1PubAddr)
 
-		core := New(backendMock, config.RoundRobin)
+		core := New(backendMock, config.DefaultConfig())
 		core.setCommitteeSet(committeeSet)
 		core.lastHeader = prevBlock.Header()
 		err = core.handleMsg(context.Background(), msgRlpWithSig)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -617,7 +617,6 @@ func (s *Ethereum) glienickeEventLoop(server *p2p.Server) {
 // Stop implements node.Service, terminating all internal goroutines used by the
 // Ethereum protocol.
 func (s *Ethereum) Stop() error {
-	s.eventMux.Stop()
 	// Stop all the peer-related stuff first.
 	s.protocolManager.Stop()
 	if s.lesServer != nil {
@@ -632,5 +631,6 @@ func (s *Ethereum) Stop() error {
 	s.blockchain.Stop()
 	s.engine.Close()
 	s.chainDb.Close()
+	s.eventMux.Stop()
 	return nil
 }

--- a/params/version.go
+++ b/params/version.go
@@ -22,8 +22,8 @@ import (
 
 const (
 	VersionMajor = 0  // Major version component of the current release
-	VersionMinor = 4  // Minor version component of the current release
-	VersionPatch = 2  // Patch version component of the current release
+	VersionMinor = 5  // Minor version component of the current release
+	VersionPatch = 0  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
- Improve support for block periods greater than one second by making the mining logic block-period aware and making sure that the initial propose timeout value is set accordingly.
- Potentially fix for https://github.com/clearmatics/autonity/issues/604
- Bump Autonity version to 0.5