### PR TITLE
Prevent unintended test runs in ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -299,7 +299,8 @@ jobs:
         run: make embed-autonity-contract
 
       - name: Test
-        run: go test ./consensus/test/... -v -run='${{ matrix.e2e }}' -timeout 40m
+        # \b matches a word boundary
+        run: go test ./consensus/test/... -v -run='\b${{ matrix.e2e }}\b' -timeout 40m
 
   race_tests:
     needs: bootstrap-checkout


### PR DESCRIPTION
When using a github actions matrix to run tests we were specifying
specific tests to run by name. Using this approach 'go test' will run
all tests with a matching prefix, which  in our case was causing us to
run tests more than once.

For example the following 2 matrix entries would cause
TestTendermintMajorityExternalUsersFullyConnected to be executed on each
run.

  TestTendermintMajorityExternalUsers,
  TestTendermintMajorityExternalUsersFullyConnected,

This commit updates the matching regex to match the word boundaries at
the beginning and end of the test name so that we only run the specified
test.