### PR TITLE
Fix docker image build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -369,3 +369,30 @@ jobs:
 
       - name: test contract
         run: make test-contracts
+
+  # Builds the docker image. We don't intend to use the built image as part of
+  # a workflow, but we want to know the image can be built.
+  docker-image-build:
+    # Don't try to build the docker image unless autonity itself builds.
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Cache code
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-autonity-code
+        with:
+          path: /home/runner/work/autonity/autonity/
+          key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ github.sha }}
+
+      - uses: actions/checkout@v2
+        if: steps.cache-autonity-code.outputs.cache-hit != 'true'
+        with:
+          clean: 'false'
+
+      - name: Embed Autonity contract
+        if:  steps.cache-autonity-code.outputs.cache-hit != 'true'
+        run: make embed-autonity-contract
+
+      - name: Build
+        run: make build-docker-image

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,18 @@ jobs:
   bootstrap-checkout:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Set GOPATH
+        run: |
+          echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
+          echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
+        shell: bash
+
       - name: Cache code
         uses: actions/cache@v1
         id: cache-autonity-code

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -383,28 +383,17 @@ jobs:
         run: make test-contracts
 
   # Builds the docker image. We don't intend to use the built image as part of
-  # a workflow, but we want to know the image can be built.
+  # a workflow, but we want to know the image can be built. We don't want to
+  # use any cache here since we want a clean checkout before any code
+  # generation has taken place.
   docker-image-build:
-    # Don't try to build the docker image unless autonity itself builds.
     runs-on: ubuntu-latest
+    # Don't try to build the docker image unless autonity itself builds.
     needs: build
     steps:
-      - name: Cache code
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-autonity-code
-        with:
-          path: /home/runner/work/autonity/autonity/
-          key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ github.sha }}
-
       - uses: actions/checkout@v2
-        if: steps.cache-autonity-code.outputs.cache-hit != 'true'
         with:
           clean: 'false'
-
-      - name: Embed Autonity contract
-        if:  steps.cache-autonity-code.outputs.cache-hit != 'true'
-        run: make embed-autonity-contract
 
       - name: Build
         run: make build-docker-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build Autonity in a stock Go builder container
 FROM golang:1.14-alpine as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers libc-dev git
+RUN apk add --no-cache make gcc musl-dev linux-headers libc-dev git perl-utils
 
 ADD . /autonity
 RUN cd /autonity && make autonity

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 .PHONY: autonity-windows autonity-windows-386 autonity-windows-amd64
 
 NPMBIN= $(shell npm bin)
-GOBIN = ./build/bin
+BINDIR = ./build/bin
 GO ?= latest
 LATEST_COMMIT ?= $(shell git log -n 1 develop --pretty=format:"%H")
 ifeq ($(LATEST_COMMIT),)
@@ -51,7 +51,7 @@ build-docker-image:
 autonity: embed-autonity-contract
 	build/env.sh go run build/ci.go install ./cmd/autonity
 	@echo "Done building."
-	@echo "Run \"$(GOBIN)/autonity\" to launch autonity."
+	@echo "Run \"$(BINDIR)/autonity\" to launch autonity."
 
 embed-autonity-contract: $(GENERATED_BYTECODE) $(GENERATED_ABI)
 
@@ -83,12 +83,12 @@ all: embed-autonity-contract
 android:
 	build/env.sh go run build/ci.go aar --local
 	@echo "Done building."
-	@echo "Import \"$(GOBIN)/autonity.aar\" to use the library."
+	@echo "Import \"$(BINDIR)/autonity.aar\" to use the library."
 
 ios:
 	build/env.sh go run build/ci.go xcode --local
 	@echo "Done building."
-	@echo "Import \"$(GOBIN)/autonity.framework\" to use the library."
+	@echo "Import \"$(BINDIR)/autonity.framework\" to use the library."
 
 test: all
 	build/env.sh go run build/ci.go test -coverage
@@ -161,19 +161,19 @@ lint-deps:
 
 clean:
 	go clean -cache
-	rm -fr build/_workspace/pkg/ $(GOBIN)/*
+	rm -fr build/_workspace/pkg/ $(BINDIR)/*
 	rm -rf $(GENERATED_CONTRACT_DIR)
 
 # The devtools target installs tools required for 'go generate'.
-# You need to put $GOBIN (or $GOPATH/bin) in your PATH to use 'go generate'.
+# You need to put $BINDIR (or $GOPATH/bin) in your PATH to use 'go generate'.
 
 devtools:
 	go get -u github.com/golang/mock/mockgen
-	env GOBIN= go get -u golang.org/x/tools/cmd/stringer
-	env GOBIN= go get -u github.com/kevinburke/go-bindata/go-bindata
-	env GOBIN= go get -u github.com/fjl/gencodec
-	env GOBIN= go get -u github.com/golang/protobuf/protoc-gen-go
-	env GOBIN= go install ./cmd/abigen
+	env BINDIR= go get -u golang.org/x/tools/cmd/stringer
+	env BINDIR= go get -u github.com/kevinburke/go-bindata/go-bindata
+	env BINDIR= go get -u github.com/fjl/gencodec
+	env BINDIR= go get -u github.com/golang/protobuf/protoc-gen-go
+	env BINDIR= go install ./cmd/abigen
 	@type "npm" 2> /dev/null || echo 'Please install node.js and npm'
 	@type "solc" 2> /dev/null || echo 'Please install solc'
 	@type "protoc" 2> /dev/null || echo 'Please install protoc'
@@ -182,90 +182,90 @@ devtools:
 
 autonity-cross: autonity-linux autonity-darwin autonity-windows autonity-android autonity-ios
 	@echo "Full cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-*
+	@ls -ld $(BINDIR)/autonity-*
 
 autonity-linux: autonity-linux-386 autonity-linux-amd64 autonity-linux-arm autonity-linux-mips64 autonity-linux-mips64le
 	@echo "Linux cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-*
+	@ls -ld $(BINDIR)/autonity-linux-*
 
 autonity-linux-386:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=linux/386 -v ./cmd/autonity
 	@echo "Linux 386 cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-* | grep 386
+	@ls -ld $(BINDIR)/autonity-linux-* | grep 386
 
 autonity-linux-amd64:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=linux/amd64 -v ./cmd/autonity
 	@echo "Linux amd64 cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-* | grep amd64
+	@ls -ld $(BINDIR)/autonity-linux-* | grep amd64
 
 autonity-linux-arm: autonity-linux-arm-5 autonity-linux-arm-6 autonity-linux-arm-7 autonity-linux-arm64
 	@echo "Linux ARM cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-* | grep arm
+	@ls -ld $(BINDIR)/autonity-linux-* | grep arm
 
 autonity-linux-arm-5:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=linux/arm-5 -v ./cmd/autonity
 	@echo "Linux ARMv5 cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-* | grep arm-5
+	@ls -ld $(BINDIR)/autonity-linux-* | grep arm-5
 
 autonity-linux-arm-6:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=linux/arm-6 -v ./cmd/autonity
 	@echo "Linux ARMv6 cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-* | grep arm-6
+	@ls -ld $(BINDIR)/autonity-linux-* | grep arm-6
 
 autonity-linux-arm-7:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=linux/arm-7 -v ./cmd/autonity
 	@echo "Linux ARMv7 cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-* | grep arm-7
+	@ls -ld $(BINDIR)/autonity-linux-* | grep arm-7
 
 autonity-linux-arm64:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=linux/arm64 -v ./cmd/autonity
 	@echo "Linux ARM64 cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-* | grep arm64
+	@ls -ld $(BINDIR)/autonity-linux-* | grep arm64
 
 autonity-linux-mips:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=linux/mips --ldflags '-extldflags "-static"' -v ./cmd/autonity
 	@echo "Linux MIPS cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-* | grep mips
+	@ls -ld $(BINDIR)/autonity-linux-* | grep mips
 
 autonity-linux-mipsle:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=linux/mipsle --ldflags '-extldflags "-static"' -v ./cmd/autonity
 	@echo "Linux MIPSle cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-* | grep mipsle
+	@ls -ld $(BINDIR)/autonity-linux-* | grep mipsle
 
 autonity-linux-mips64:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=linux/mips64 --ldflags '-extldflags "-static"' -v ./cmd/autonity
 	@echo "Linux MIPS64 cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-* | grep mips64
+	@ls -ld $(BINDIR)/autonity-linux-* | grep mips64
 
 autonity-linux-mips64le:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=linux/mips64le --ldflags '-extldflags "-static"' -v ./cmd/autonity
 	@echo "Linux MIPS64le cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-linux-* | grep mips64le
+	@ls -ld $(BINDIR)/autonity-linux-* | grep mips64le
 
 autonity-darwin: autonity-darwin-386 autonity-darwin-amd64
 	@echo "Darwin cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-darwin-*
+	@ls -ld $(BINDIR)/autonity-darwin-*
 
 autonity-darwin-386:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=darwin/386 -v ./cmd/autonity
 	@echo "Darwin 386 cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-darwin-* | grep 386
+	@ls -ld $(BINDIR)/autonity-darwin-* | grep 386
 
 autonity-darwin-amd64:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=darwin/amd64 -v ./cmd/autonity
 	@echo "Darwin amd64 cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-darwin-* | grep amd64
+	@ls -ld $(BINDIR)/autonity-darwin-* | grep amd64
 
 autonity-windows: autonity-windows-386 autonity-windows-amd64
 	@echo "Windows cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-windows-*
+	@ls -ld $(BINDIR)/autonity-windows-*
 
 autonity-windows-386:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=windows/386 -v ./cmd/autonity
 	@echo "Windows 386 cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-windows-* | grep 386
+	@ls -ld $(BINDIR)/autonity-windows-* | grep 386
 
 autonity-windows-amd64:
 	build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=windows/amd64 -v ./cmd/autonity
 	@echo "Windows amd64 cross compilation done:"
-	@ls -ld $(GOBIN)/autonity-windows-* | grep amd64
+	@ls -ld $(BINDIR)/autonity-windows-* | grep amd64

--- a/Makefile
+++ b/Makefile
@@ -64,16 +64,18 @@ $(GENERATED_BYTECODE) $(GENERATED_ABI): $(AUTONITY_CONTRACT_DIR)/$(AUTONITY_CONT
 	$(DOCKER_SUDO) docker run --rm -v $(CURDIR)/$(AUTONITY_CONTRACT_DIR):/contracts -v $(CURDIR)/$(GENERATED_CONTRACT_DIR):/output ethereum/solc:0.6.4 --overwrite --abi --bin -o /output /contracts/$(AUTONITY_CONTRACT)
 
 	@echo Generating $(GENERATED_BYTECODE)
-	@echo 'package generated\n' > $(GENERATED_BYTECODE)
+	@echo 'package generated' > $(GENERATED_BYTECODE)
 	@echo -n 'const Bytecode = "' >> $(GENERATED_BYTECODE)
 	@cat  $(GENERATED_CONTRACT_DIR)/Autonity.bin >> $(GENERATED_BYTECODE)
 	@echo '"' >> $(GENERATED_BYTECODE)
+	@gofmt -s -w $(GENERATED_BYTECODE)
 
 	@echo Generating $(GENERATED_ABI)
-	@echo 'package generated\n' > $(GENERATED_ABI)
+	@echo 'package generated' > $(GENERATED_ABI)
 	@echo -n 'const Abi = `' >> $(GENERATED_ABI)
 	@cat  $(GENERATED_CONTRACT_DIR)/Autonity.abi | json_pp  >> $(GENERATED_ABI)
 	@echo '`' >> $(GENERATED_ABI)
+	@gofmt -s -w $(GENERATED_ABI)
 
 all: embed-autonity-contract
 	build/env.sh go run build/ci.go install

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ GENERATED_BYTECODE = $(GENERATED_CONTRACT_DIR)/bytecode.go
 # we then echo "sudo".
 DOCKER_SUDO = $(shell [ `id -u` -eq 0 ] || id -nG $(USER) | grep "\<docker\>" > /dev/null || echo sudo )
 
+# Builds the docker image and checks that we can run the autonity binary inside it
+build-docker-image:
+	@$(DOCKER_SUDO) docker build -t autonity .
+	@$(DOCKER_SUDO) docker run --rm autonity -h > /dev/null
+
 autonity: embed-autonity-contract
 	build/env.sh go run build/ci.go install ./cmd/autonity
 	@echo "Done building."

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,14 @@ GENERATED_BYTECODE = $(GENERATED_CONTRACT_DIR)/bytecode.go
 # we then echo "sudo".
 DOCKER_SUDO = $(shell [ `id -u` -eq 0 ] || id -nG $(USER) | grep "\<docker\>" > /dev/null || echo sudo )
 
-# Builds the docker image and checks that we can run the autonity binary inside it
+# Builds the docker image and checks that we can run the autonity binary inside
+# it. We need to run embed-autonity-contract before running the docker build
+# here since embed-autonity-contract makes use of "docker run" which cannot be
+# run inside of a "docker build", by running it before we ensure that the make
+# targets are up to date and that when running make inside the docker image
+# there is nothing to do for the embed-autonity-contract rule. 
 build-docker-image:
+	make embed-autonity-contract
 	@$(DOCKER_SUDO) docker build -t autonity .
 	@$(DOCKER_SUDO) docker run --rm autonity -h > /dev/null
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ This generates go source from the autonity contract.
 make autonity
 ```
 
+## Build Autonity docker image
+
+```
+make build-docker-image
+```
+
 ## License
 
 The go-ethereum library (i.e. all code outside of the `cmd` directory) is licensed under the


### PR DESCRIPTION
Fixes #618

The docker file build was failing since we had updated the Makefile to run docker with or without sudo based on whether the current user was in the docker group. The assumption being that if you are not in the docker group you need to use sudo, which works sometimes but not in the case that the user is root and sudo is not installed.

This PR ensures that if the user is root, we do not try to use sudo.

It also adds a Makefile rule to build the docker image and a ci job to build the docker image.

This PR changed a bit during the course of its existence.

A number of other problems were found and resolved.

* The build would fail if we tried to run docker during a docker build. This would happen when running the embed-autonity-contract rule(it ran a dockerised solc to compile the contract), but it would only happen if make detected that the generated contract code was out of date, so we could avoid running this step inside the docker build by running `make embed-autonity-contract` before the docker build so that the files added to the docker container included up to date generated contract code.

* If the systems 'sh' shell was bash the embed-autonity-contract rule would generate invalid code. This is due to the bash implementation of echo not interpreting `\n`as a newline unless it is provided the `e` flag. This was resolved by removing use of `\n` and instead using gofmt to fmt the generatd files.

* @eastata made us aware that devops require docker builds to succeed on a host with only docker installed, this meant we couldn't rely on running `make embed-autonity-contract` before running the docker build. This was solved by not using a dockerised version of solc. The reason we chose a dockerised version of solc to begin with was it downloaded much more quickly than the binary from github and it meant the process supported both mac and linux machines. As we now no longer have any team members using mac its not so important to support it.

