### PR TITLE
Skip intermittently failing e2e tests

### DIFF
--- a/consensus/test/autonity_contract_test.go
+++ b/consensus/test/autonity_contract_test.go
@@ -227,6 +227,8 @@ func TestCheckBlockWithSmallFee(t *testing.T) {
 }
 
 func TestRemoveFromValidatorsList(t *testing.T) {
+	// to be tracked by https://github.com/clearmatics/autonity/issues/604
+	t.Skip("skipping test since the upstream update cause local e2e test framework go routine leak.")
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}

--- a/consensus/test/start_stop_test.go
+++ b/consensus/test/start_stop_test.go
@@ -363,6 +363,7 @@ func TestTendermintStartStopFPlusOneNodes(t *testing.T) {
 }
 
 func TestTendermintStartStopFPlusTwoNodes(t *testing.T) {
+	t.Skip("This test fails intermittently see https://github.com/clearmatics/autonity/issues/624")
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}

--- a/consensus/test/start_stop_test.go
+++ b/consensus/test/start_stop_test.go
@@ -149,6 +149,8 @@ func TestTendermintStartStopSingleNode(t *testing.T) {
 }
 
 func TestTendermintStartStopFNodes(t *testing.T) {
+	// to be tracked by https://github.com/clearmatics/autonity/issues/604
+	t.Skip("skipping test since the upstream update cause local e2e test framework go routine leak.")
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}

--- a/consensus/test/topology_roles_test.go
+++ b/consensus/test/topology_roles_test.go
@@ -46,6 +46,7 @@ func TestTendermintExternalUser(t *testing.T) {
 }
 
 func TestTendermintMajorityExternalUsers(t *testing.T) {
+	t.Skip("This test is intermittently failing, see - https://github.com/clearmatics/autonity/issues/619")
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}


### PR DESCRIPTION
These tests became flaky after the upstream upgrade #549 

They are to be fixed in #604, #619 and #624 