### PR TITLE
Add detailed panic to provide better feedback #624

### DIFF
--- a/consensus/test/start_stop_test.go
+++ b/consensus/test/start_stop_test.go
@@ -363,7 +363,7 @@ func TestTendermintStartStopFPlusOneNodes(t *testing.T) {
 }
 
 func TestTendermintStartStopFPlusTwoNodes(t *testing.T) {
-	t.Skip("This test fails intermittently see https://github.com/clearmatics/autonity/issues/624")
+	// t.Skip("This test fails intermittently see https://github.com/clearmatics/autonity/issues/624")
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}

--- a/core/rawdb/rawdb_assumptions_test.go
+++ b/core/rawdb/rawdb_assumptions_test.go
@@ -1,0 +1,44 @@
+package rawdb
+
+import (
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/clearmatics/autonity/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRawdbAccessReturnsNilWhenDatabaseClosed(t *testing.T) {
+	temp, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(temp)
+
+	root := filepath.Join(temp, "chaindata")
+	freezer := filepath.Join(root, "ancient")
+
+	db, err := NewLevelDBDatabaseWithFreezer(
+		root,
+		256,
+		256,
+		freezer,
+		"eth/db/chaindata/",
+	)
+
+	require.NoError(t, err)
+
+	hash := common.Hash{}
+	var num uint64 = 1
+	td := big.NewInt(10)
+	WriteTd(db, hash, num, td)
+	retrieved := ReadTd(db, hash, num)
+	assert.Equal(t, retrieved, td)
+	err = db.Close()
+	require.NoError(t, err)
+	retrieved = ReadTd(db, hash, num)
+	var nilBigInt *big.Int
+	assert.Equal(t, retrieved, nilBigInt)
+}


### PR DESCRIPTION
The panic mentioned in https://github.com/clearmatics/autonity/issues/624 is occurring when the
second parameter to big.Int.Add is nil which is in turn caused by
blockchain.GetTd returning nil for the parent of the current block. The
panic happens rarely and we need more knowledge of what is the current
state to better understand how it is ocurring.

This commit adds a much more detailed panic that includes a dump of the
child block and the specific arguments in the call to blockchain.GetTd.