### PR TITLE
Disable freezer on 0.4.x release

### DIFF
--- a/cmd/autonity/chaincmd.go
+++ b/cmd/autonity/chaincmd.go
@@ -453,6 +453,8 @@ func copyDb(ctx *cli.Context) error {
 	dl := downloader.New(0, chainDb, syncBloom, new(event.TypeMux), chain, nil, nil)
 
 	// Create a source peer to satisfy downloader requests from
+
+	panic("freezer")
 	db, err := rawdb.NewLevelDBDatabaseWithFreezer(ctx.Args().First(), ctx.GlobalInt(utils.CacheFlag.Name)/2, 256, ctx.Args().Get(1), "")
 	if err != nil {
 		return err

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -139,7 +139,7 @@ func New(ctx *node.ServiceContext, config *Config, cons func(basic consensus.Eng
 	log.Info("Allocated trie memory caches", "clean", common.StorageSize(config.TrieCleanCache)*1024*1024, "dirty", common.StorageSize(config.TrieDirtyCache)*1024*1024)
 
 	// Assemble the Ethereum object
-	chainDb, err := ctx.OpenDatabaseWithFreezer("chaindata", config.DatabaseCache, config.DatabaseHandles, config.DatabaseFreezer, "eth/db/chaindata/")
+	chainDb, err := ctx.OpenDatabase("chaindata", config.DatabaseCache, config.DatabaseHandles, "eth/db/chaindata/")
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -651,6 +651,7 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer,
 	case !filepath.IsAbs(freezer):
 		freezer = n.config.ResolvePath(freezer)
 	}
+	panic("freezer")
 	return rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace)
 }
 


### PR DESCRIPTION
This disables the freezer on the 0.4.x release. A 0.4.1 release will be cut after merge.

This will act as a hotfix for the 0.4.0 release. 