### PR TITLE
ReadHeaderRLP returns both the encoded and decode header values

### DIFF
--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -49,7 +49,7 @@ func TestHeaderStorage(t *testing.T) {
 	} else if entry.Hash() != header.Hash() {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, header)
 	}
-	if entry := ReadHeaderRLP(db, header.Hash(), header.Number.Uint64()); entry == nil {
+	if entry, _ := ReadHeaderRLP(db, header.Hash(), header.Number.Uint64()); entry == nil {
 		t.Fatalf("Stored header RLP not found")
 	} else {
 		hasher := sha3.NewLegacyKeccak256()
@@ -415,7 +415,7 @@ func TestAncientStorage(t *testing.T) {
 
 		// Ensure nothing non-existent will be read
 		hash, number := block.Hash(), block.NumberU64()
-		if blob := ReadHeaderRLP(db, hash, number); len(blob) > 0 {
+		if blob, _ := ReadHeaderRLP(db, hash, number); len(blob) > 0 {
 			t.Fatalf("non existent header returned")
 		}
 		if blob := ReadBodyRLP(db, hash, number); len(blob) > 0 {
@@ -429,7 +429,7 @@ func TestAncientStorage(t *testing.T) {
 		}
 		// Write and verify the header in the database
 		WriteAncientBlock(db, block, nil, big.NewInt(100))
-		if blob := ReadHeaderRLP(db, hash, number); len(blob) == 0 {
+		if blob, _ := ReadHeaderRLP(db, hash, number); len(blob) == 0 {
 			t.Fatalf("no header returned")
 		}
 		if blob := ReadBodyRLP(db, hash, number); len(blob) == 0 {
@@ -443,7 +443,7 @@ func TestAncientStorage(t *testing.T) {
 		}
 		// Use a fake hash for data retrieval, nothing should be returned.
 		fakeHash := common.BytesToHash([]byte{0x01, 0x02, 0x03})
-		if blob := ReadHeaderRLP(db, fakeHash, number); len(blob) != 0 {
+		if blob, _ := ReadHeaderRLP(db, fakeHash, number); len(blob) != 0 {
 			t.Fatalf("invalid header returned")
 		}
 		if blob := ReadBodyRLP(db, fakeHash, number); len(blob) != 0 {

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -320,7 +320,7 @@ func (f *freezer) freeze(db ethdb.KeyValueStore) {
 				log.Error("Canonical hash missing, can't freeze", "number", f.frozen)
 				break
 			}
-			header := ReadHeaderRLP(nfdb, hash, f.frozen)
+			header, _ := ReadHeaderRLP(nfdb, hash, f.frozen)
 			if len(header) == 0 {
 				log.Error("Block header missing, can't freeze", "number", f.frozen, "hash", hash)
 				break

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -877,7 +877,8 @@ func (h *serverHandler) getAuxiliaryHeaders(req HelperTrieReq) []byte {
 	if req.Type == htCanonical && req.AuxReq == auxHeader && len(req.Key) == 8 {
 		blockNum := binary.BigEndian.Uint64(req.Key)
 		hash := rawdb.ReadCanonicalHash(h.chainDb, blockNum)
-		return rawdb.ReadHeaderRLP(h.chainDb, hash, blockNum)
+		headerRLP, _ := rawdb.ReadHeaderRLP(h.chainDb, hash, blockNum)
+		return headerRLP
 	}
 	return nil
 }


### PR DESCRIPTION
This is in order to prevent decoding the value twice, therefore, it is
up to the caller to determine how to use these returned values.make