### PR TITLE
Fix future height message handling

### DIFF
--- a/consensus/tendermint/backend/backend.go
+++ b/consensus/tendermint/backend/backend.go
@@ -154,7 +154,7 @@ func (sb *Backend) postEvent(event interface{}) {
 }
 
 func (sb *Backend) AskSync(header *types.Header) {
-	sb.logger.Info("Broadcasting consensus sync-me")
+	sb.logger.Info("Broadcasting consensus synchronization request")
 
 	targets := make(map[common.Address]struct{})
 	for _, val := range header.Committee {
@@ -439,13 +439,8 @@ func (sb *Backend) SyncPeer(address common.Address) {
 	}
 	messages := sb.core.GetCurrentHeightMessages()
 	for _, msg := range messages {
-		payload, err := msg.Payload()
-		if err != nil {
-			sb.logger.Debug("Sending", "code", msg.GetCode(), "sig", msg.GetSignature(), "err", err)
-			continue
-		}
 		//We do not save sync messages in the arc cache as recipient could not have been able to process some previous sent.
-		go p.Send(tendermintMsg, payload) //nolint
+		go p.Send(tendermintMsg, msg.Payload()) //nolint
 	}
 }
 
@@ -456,4 +451,10 @@ func (sb *Backend) ResetPeerCache(address common.Address) {
 		m, _ = ms.(*lru.ARCCache)
 		m.Purge()
 	}
+}
+
+func (sb *Backend) RemoveMessageFromLocalCache(payload []byte) {
+	// Note: ARC is thread-safe
+	hash := types.RLPHash(payload)
+	sb.knownMessages.Remove(hash)
 }

--- a/consensus/tendermint/backend/backend_test.go
+++ b/consensus/tendermint/backend/backend_test.go
@@ -406,10 +406,7 @@ func TestSyncPeer(t *testing.T) {
 		peersAddrMap := make(map[common.Address]struct{})
 		peersAddrMap[peerAddr1] = struct{}{}
 
-		payload, err := messages[0].Payload()
-		if err != nil {
-			t.Fatalf("Expected <nil>, got %v", err)
-		}
+		payload := messages[0].Payload()
 
 		peer1Mock := consensus.NewMockPeer(ctrl)
 		peer1Mock.EXPECT().Send(uint64(tendermintMsg), payload)

--- a/consensus/tendermint/core/backend_mock.go
+++ b/consensus/tendermint/core/backend_mock.go
@@ -173,6 +173,18 @@ func (mr *MockBackendMockRecorder) Post(ev interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MockBackend)(nil).Post), ev)
 }
 
+// Post mocks base method
+func (m *MockBackend) RemoveMessageFromLocalCache(payload interface{}) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RemoveMessageFromLocalCache", payload)
+}
+
+// Post indicates an expected call of Post
+func (mr *MockBackendMockRecorder) RemoveMessageFromLocalCache(payload interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMessageFromLocalCache", reflect.TypeOf((*MockBackend)(nil).RemoveMessageFromLocalCache), payload)
+}
+
 // SetProposedBlockHash mocks base method
 func (m *MockBackend) SetProposedBlockHash(hash common.Hash) {
 	m.ctrl.T.Helper()

--- a/consensus/tendermint/core/backend_mock.go
+++ b/consensus/tendermint/core/backend_mock.go
@@ -180,7 +180,7 @@ func (m *MockBackend) RemoveMessageFromLocalCache(payload []byte) {
 }
 
 // Post indicates an expected call of Post
-func (mr *MockBackendMockRecorder) RemoveMessageFromLocalCache(payload []byte) *gomock.Call {
+func (mr *MockBackendMockRecorder) RemoveMessageFromLocalCache(payload interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMessageFromLocalCache", reflect.TypeOf((*MockBackend)(nil).RemoveMessageFromLocalCache), payload)
 }

--- a/consensus/tendermint/core/backend_mock.go
+++ b/consensus/tendermint/core/backend_mock.go
@@ -174,13 +174,13 @@ func (mr *MockBackendMockRecorder) Post(ev interface{}) *gomock.Call {
 }
 
 // Post mocks base method
-func (m *MockBackend) RemoveMessageFromLocalCache(payload interface{}) {
+func (m *MockBackend) RemoveMessageFromLocalCache(payload []byte) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RemoveMessageFromLocalCache", payload)
 }
 
 // Post indicates an expected call of Post
-func (mr *MockBackendMockRecorder) RemoveMessageFromLocalCache(payload interface{}) *gomock.Call {
+func (mr *MockBackendMockRecorder) RemoveMessageFromLocalCache(payload []byte) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMessageFromLocalCache", reflect.TypeOf((*MockBackend)(nil).RemoveMessageFromLocalCache), payload)
 }

--- a/consensus/tendermint/core/backlog.go
+++ b/consensus/tendermint/core/backlog.go
@@ -155,11 +155,17 @@ func (c *core) processBacklog() {
 		c.backlogs[src] = backlog
 
 	}
-	for _, msg := range c.backlogUnchecked[c.height.Uint64()] {
-		go c.sendEvent(backlogUncheckedEvent{
-			msg: msg,
-		})
-		c.logger.Debug("Post unchecked backlog event", "msg", msg)
+	for height, _ := range c.backlogUnchecked {
+		if height == c.height.Uint64() {
+			for _, msg := range c.backlogUnchecked[height] {
+				go c.sendEvent(backlogUncheckedEvent{
+					msg: msg,
+				})
+				c.logger.Debug("Post unchecked backlog event", "msg", msg)
+			}
+		}
+		if height <= c.height.Uint64() {
+			delete(c.backlogUnchecked, height)
+		}
 	}
-	delete(c.backlogUnchecked, c.height.Uint64())
 }

--- a/consensus/tendermint/core/backlog.go
+++ b/consensus/tendermint/core/backlog.go
@@ -93,7 +93,7 @@ func (c *core) storeUncheckedBacklog(msg *Message) {
 	// We discard the furthest ahead messages in priority.
 	if c.backlogUncheckedLen == MaxSizeBacklogUnchecked+1 {
 		maxHeight := msgHeight.Uint64()
-		for k, _ := range c.backlogUnchecked {
+		for k := range c.backlogUnchecked {
 			if k > maxHeight && len(c.backlogUnchecked[k]) > 0 {
 				maxHeight = k
 			}
@@ -159,7 +159,7 @@ func (c *core) processBacklog() {
 		c.backlogs[src] = backlog
 
 	}
-	for height, _ := range c.backlogUnchecked {
+	for height := range c.backlogUnchecked {
 		if height == c.height.Uint64() {
 			for _, msg := range c.backlogUnchecked[height] {
 				go c.sendEvent(backlogUncheckedEvent{

--- a/consensus/tendermint/core/backlog.go
+++ b/consensus/tendermint/core/backlog.go
@@ -91,10 +91,10 @@ func (c *core) storeUncheckedBacklog(msg *Message) {
 	c.backlogUnchecked[msgHeight.Uint64()] = append(c.backlogUnchecked[msgHeight.Uint64()], msg)
 	c.backlogUncheckedLen += 1
 	// We discard the furthest ahead messages in priority.
-	if c.backlogUncheckedLen == MaxSizeBacklogUnchecked {
+	if c.backlogUncheckedLen == MaxSizeBacklogUnchecked+1 {
 		maxHeight := msgHeight.Uint64()
 		for k, _ := range c.backlogUnchecked {
-			if k > maxHeight {
+			if k > maxHeight && len(c.backlogUnchecked[k]) > 0 {
 				maxHeight = k
 			}
 		}
@@ -106,6 +106,10 @@ func (c *core) storeUncheckedBacklog(msg *Message) {
 		// Remove it from the backlog buffer.
 		c.backlogUnchecked[maxHeight] = c.backlogUnchecked[maxHeight][:len(c.backlogUnchecked[maxHeight])-1]
 		c.backlogUncheckedLen -= 1
+
+		if len(c.backlogUnchecked[maxHeight]) == 0 {
+			delete(c.backlogUnchecked, maxHeight)
+		}
 	}
 
 }

--- a/consensus/tendermint/core/backlog.go
+++ b/consensus/tendermint/core/backlog.go
@@ -89,7 +89,7 @@ func (c *core) storeUncheckedBacklog(msg *Message) {
 	}
 
 	c.backlogUnchecked[msgHeight.Uint64()] = append(c.backlogUnchecked[msgHeight.Uint64()], msg)
-	c.backlogUncheckedLen += 1
+	c.backlogUncheckedLen++
 	// We discard the furthest ahead messages in priority.
 	if c.backlogUncheckedLen == MaxSizeBacklogUnchecked+1 {
 		maxHeight := msgHeight.Uint64()
@@ -105,7 +105,7 @@ func (c *core) storeUncheckedBacklog(msg *Message) {
 
 		// Remove it from the backlog buffer.
 		c.backlogUnchecked[maxHeight] = c.backlogUnchecked[maxHeight][:len(c.backlogUnchecked[maxHeight])-1]
-		c.backlogUncheckedLen -= 1
+		c.backlogUncheckedLen--
 
 		if len(c.backlogUnchecked[maxHeight]) == 0 {
 			delete(c.backlogUnchecked, maxHeight)

--- a/consensus/tendermint/core/backlog_test.go
+++ b/consensus/tendermint/core/backlog_test.go
@@ -1,16 +1,14 @@
 package core
 
 import (
+	"github.com/clearmatics/autonity/common"
+	"github.com/clearmatics/autonity/core/types"
+	"github.com/clearmatics/autonity/log"
+	"github.com/golang/mock/gomock"
 	"math/big"
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/golang/mock/gomock"
-
-	"github.com/clearmatics/autonity/common"
-	"github.com/clearmatics/autonity/core/types"
-	"github.com/clearmatics/autonity/log"
 )
 
 func TestCheckMessage(t *testing.T) {
@@ -265,7 +263,6 @@ func TestProcessBacklog(t *testing.T) {
 		val, _ := committeeSet.GetByIndex(0)
 
 		expected := backlogEvent{
-			src: val,
 			msg: msg,
 		}
 

--- a/consensus/tendermint/core/backlog_test.go
+++ b/consensus/tendermint/core/backlog_test.go
@@ -327,7 +327,6 @@ func TestProcessBacklog(t *testing.T) {
 		val, _ := committeeSet.GetByIndex(0)
 
 		expected := backlogEvent{
-			src: val,
 			msg: msg,
 		}
 
@@ -402,7 +401,6 @@ func TestProcessBacklog(t *testing.T) {
 		val, _ := committeeSet.GetByIndex(0)
 
 		expected := backlogEvent{
-			src: val,
 			msg: msg,
 		}
 

--- a/consensus/tendermint/core/core_backend.go
+++ b/consensus/tendermint/core/core_backend.go
@@ -58,6 +58,10 @@ type Backend interface {
 
 	//Used to set the blockchain on this
 	SetBlockchain(bc *ethcore.BlockChain)
+
+	// RemoveMessageFromLocalCache removes a local message from the known messages cache.
+	// It is called by core when some unprocessed messages are removed from the untrusted backlog buffer.
+	RemoveMessageFromLocalCache(payload []byte)
 }
 
 type Tendermint interface {

--- a/consensus/tendermint/core/handler.go
+++ b/consensus/tendermint/core/handler.go
@@ -130,30 +130,29 @@ eventLoop:
 			// A real ev arrived, process interesting content
 			switch e := ev.Data.(type) {
 			case events.MessageEvent:
-				// ecrire test of len(0)
 				msg := new(Message)
 				if err := msg.FromPayload(e.Payload); err != nil {
-					c.logger.Error("core.mainEventLoop Get message(MessageEvent) invalid payload")
+					c.logger.Error("consensus message invalid payload", "err", err)
 					continue
 				}
 				if err := c.handleMsg(ctx, msg); err != nil {
-					c.logger.Debug("core.mainEventLoop Get message(MessageEvent) payload failed", "err", err)
+					c.logger.Debug("MessageEvent payload failed", "err", err)
 					continue
 				}
 				c.backend.Gossip(ctx, c.committeeSet().Committee(), e.Payload)
 			case backlogEvent:
 				// No need to check signature for internal messages
-				c.logger.Debug("Started handling backlogEvent")
+				c.logger.Debug("started handling backlogEvent")
 				if err := c.handleCheckedMsg(ctx, e.msg); err != nil {
-					c.logger.Debug("core.mainEventLoop handleCheckedMsg message failed", "err", err)
+					c.logger.Debug("backlogEvent message handling failed", "err", err)
 					continue
 				}
 				c.backend.Gossip(ctx, c.committeeSet().Committee(), e.msg.Payload())
 
 			case backlogUncheckedEvent:
-				c.logger.Debug("Started handling backlogUncheckedEvent")
+				c.logger.Debug("started handling backlogUncheckedEvent")
 				if err := c.handleMsg(ctx, e.msg); err != nil {
-					c.logger.Debug("core.mainEventLoop backlogUncheckedEvent message failed", "err", err)
+					c.logger.Debug("backlogUncheckedEvent message failed", "err", err)
 					continue
 				}
 				c.backend.Gossip(ctx, c.committeeSet().Committee(), e.msg.Payload())

--- a/consensus/tendermint/core/handler_test.go
+++ b/consensus/tendermint/core/handler_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"github.com/influxdata/influxdb/pkg/deep"
+	"github.com/stretchr/testify/require"
 	"math/big"
 	"testing"
 
@@ -195,9 +196,11 @@ func TestHandleMsg(t *testing.T) {
 			Height:            big.NewInt(1),
 			ProposedBlockHash: common.BytesToHash([]byte{0x1}),
 		}
+		payload, err := rlp.EncodeToBytes(vote)
+		require.NoError(t, err)
 		msg := &Message{
 			Code:       msgPrevote,
-			Msg:        MustEncode(vote),
+			Msg:        payload,
 			decodedMsg: vote,
 			Address:    common.Address{},
 		}
@@ -226,9 +229,11 @@ func TestHandleMsg(t *testing.T) {
 			Height:            big.NewInt(3),
 			ProposedBlockHash: common.BytesToHash([]byte{0x1}),
 		}
+		payload, err := rlp.EncodeToBytes(vote)
+		require.NoError(t, err)
 		msg := &Message{
 			Code:       msgPrevote,
-			Msg:        MustEncode(vote),
+			Msg:        payload,
 			decodedMsg: vote,
 			Address:    common.Address{},
 		}

--- a/consensus/tendermint/core/handler_test.go
+++ b/consensus/tendermint/core/handler_test.go
@@ -190,14 +190,16 @@ func TestHandleMsg(t *testing.T) {
 			round:    1,
 			height:   big.NewInt(2),
 		}
+		vote := &Vote{
+			Round:             2,
+			Height:            big.NewInt(1),
+			ProposedBlockHash: common.BytesToHash([]byte{0x1}),
+		}
 		msg := &Message{
-			Code: msgPrevote,
-			Msg: MustEncode(&Vote{
-				Round:             2,
-				Height:            big.NewInt(1),
-				ProposedBlockHash: common.BytesToHash([]byte{0x1}),
-			}),
-			Address: common.Address{},
+			Code:       msgPrevote,
+			Msg:        MustEncode(vote),
+			decodedMsg: vote,
+			Address:    common.Address{},
 		}
 
 		if err := c.handleMsg(context.Background(), msg); err != errOldHeightMessage {

--- a/consensus/tendermint/core/message.go
+++ b/consensus/tendermint/core/message.go
@@ -36,7 +36,6 @@ const (
 
 var (
 	errMsgPayloadNotDecoded = errors.New("message not decoded")
-	errNotCommittee         = errors.New("message not sent by committee member")
 	ErrUnauthorizedAddress  = errors.New("unauthorized address")
 )
 
@@ -228,12 +227,4 @@ func (m *Message) Height() (*big.Int, error) {
 
 func Encode(val interface{}) ([]byte, error) {
 	return rlp.EncodeToBytes(val)
-}
-
-func MustEncode(val interface{}) []byte {
-	ret, err := rlp.EncodeToBytes(val)
-	if err != nil {
-		panic("encoding failled")
-	}
-	return ret
 }

--- a/consensus/tendermint/core/message.go
+++ b/consensus/tendermint/core/message.go
@@ -229,3 +229,11 @@ func (m *Message) Height() (*big.Int, error) {
 func Encode(val interface{}) ([]byte, error) {
 	return rlp.EncodeToBytes(val)
 }
+
+func MustEncode(val interface{}) []byte {
+	ret, err := rlp.EncodeToBytes(val)
+	if err != nil {
+		panic("encoding failled")
+	}
+	return ret
+}

--- a/consensus/tendermint/core/message.go
+++ b/consensus/tendermint/core/message.go
@@ -20,13 +20,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
-	"math/big"
-	"reflect"
-
 	"github.com/clearmatics/autonity/common"
 	"github.com/clearmatics/autonity/core/types"
 	"github.com/clearmatics/autonity/rlp"
+	"io"
+	"math/big"
+	"reflect"
 )
 
 const (
@@ -140,7 +139,7 @@ func (m *Message) Validate(validateFn func(*types.Header, []byte, []byte) (commo
 
 	v := previousHeader.CommitteeMember(addr)
 	if v == nil {
-		return nil, fmt.Errorf("validator was not a committee member %q", v)
+		return nil, fmt.Errorf("message received is not from a committee member: %x", addr)
 	}
 
 	m.power = v.VotingPower.Uint64()

--- a/consensus/tendermint/core/message_test.go
+++ b/consensus/tendermint/core/message_test.go
@@ -181,7 +181,7 @@ func TestMessageValidate(t *testing.T) {
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
-						count += 1
+						count++
 					}
 				}()
 				_, _ = decMsg.Validate(validateFn, lastHeader)

--- a/consensus/tendermint/core/message_test.go
+++ b/consensus/tendermint/core/message_test.go
@@ -53,33 +53,32 @@ func TestMessageString(t *testing.T) {
 	}
 }
 
-func TestMessageFromPayload(t *testing.T) {
-	t.Run("nil validator function given, nil validator returned", func(t *testing.T) {
-		msg := &Message{
-			Code:    msgProposal,
-			Address: common.HexToAddress("0x1234567890"),
-		}
-
-		payload, _ := msg.Payload()
+func TestMessageValidate(t *testing.T) {
+	t.Run("nil validator function given, panic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expect panic")
+			}
+		}()
+		msg := createPrevote(t, common.Hash{}, 1, new(big.Int).SetUint64(26), types.CommitteeMember{})
+		lastHeader := &types.Header{Number: new(big.Int).SetUint64(1)}
+		payload := msg.Payload()
 
 		decMsg := &Message{}
-		val, err := decMsg.FromPayload(payload, nil, nil)
+		err := decMsg.FromPayload(payload)
 		if err != nil {
 			t.Fatalf("have %v, want nil", err)
 		}
-
+		val, err := decMsg.Validate(nil, lastHeader)
 		if val != nil {
 			t.Fatalf("validator must be nil, but got %v", val)
 		}
 	})
 
-	t.Run("validator function fails, nil returned", func(t *testing.T) {
-		msg := &Message{
-			Code:    msgProposal,
-			Address: common.HexToAddress("0x1234567890"),
-		}
-
-		payload, _ := msg.Payload()
+	t.Run("validate function fails, nil returned", func(t *testing.T) {
+		msg := createPrevote(t, common.Hash{}, 1, new(big.Int).SetUint64(26), types.CommitteeMember{VotingPower: big.NewInt(0)})
+		lastHeader := &types.Header{Number: new(big.Int).SetUint64(25)}
+		payload := msg.Payload()
 		wantErr := errors.New("some error")
 
 		validateFn := func(previousHeader *types.Header, data []byte, sig []byte) (common.Address, error) {
@@ -87,39 +86,51 @@ func TestMessageFromPayload(t *testing.T) {
 		}
 
 		decMsg := &Message{}
-		_, err := decMsg.FromPayload(payload, nil, validateFn)
+		if err := decMsg.FromPayload(payload); err != nil {
+			t.Fatalf("have %v, want nil", err)
+		}
+		_, err := decMsg.Validate(validateFn, lastHeader)
 		if err != wantErr {
 			t.Fatalf("want error %v, got %v", wantErr, err)
 		}
 	})
 
-	t.Run("unauthorized address given, error returned", func(t *testing.T) {
-		msg := &Message{
-			Code:    msgProposal,
-			Address: common.HexToAddress("0x1234567890"),
-		}
+	t.Run("not a committee member, error returned", func(t *testing.T) {
+		member := types.CommitteeMember{common.HexToAddress("0x1234567890"), big.NewInt(1)}
 
-		payload, _ := msg.Payload()
+		msg := createPrevote(t, common.Hash{}, 1, new(big.Int).SetUint64(26), member)
+		payload := msg.Payload()
 
 		validateFn := func(previousHeader *types.Header, data []byte, sig []byte) (common.Address, error) {
-			return common.Address{}, nil
+			return member.Address, nil
 		}
-
+		lastHeader := &types.Header{Number: new(big.Int).SetUint64(25), Committee: []types.CommitteeMember{
+			{
+				Address:     common.HexToAddress("0x1234567899"),
+				VotingPower: big.NewInt(2),
+			},
+		}}
 		decMsg := &Message{}
-		_, err := decMsg.FromPayload(payload, nil, validateFn)
-		if err != ErrUnauthorizedAddress {
-			t.Fatalf("have %v, want %v", err, ErrUnauthorizedAddress)
+		if err := decMsg.FromPayload(payload); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		val, err := decMsg.Validate(validateFn, lastHeader)
+		if val != nil {
+			t.Fatal("should return nil validator")
+		}
+		if err.Error() != "message received is not from a committee member: 0000000000000000000000000000001234567890" {
+			t.Fatalf("bad error: %v", err)
 		}
 	})
 
 	t.Run("valid params given, valid validator returned", func(t *testing.T) {
 		authorizedAddress := common.HexToAddress("0x1234567890")
-		msg := &Message{
-			Code:    msgProposal,
-			Address: authorizedAddress,
-		}
-
-		payload, _ := msg.Payload()
+		msg := createPrevote(t, common.Hash{}, 1, new(big.Int).SetUint64(26),
+			types.CommitteeMember{
+				Address:     authorizedAddress,
+				VotingPower: big.NewInt(1),
+			})
+		payload := msg.Payload()
 
 		val := types.CommitteeMember{
 			Address:     authorizedAddress,
@@ -128,19 +139,56 @@ func TestMessageFromPayload(t *testing.T) {
 
 		h := types.Header{
 			Committee: types.Committee{val},
+			Number:    big.NewInt(25),
 		}
 		validateFn := func(previousHeader *types.Header, data []byte, sig []byte) (common.Address, error) {
 			return authorizedAddress, nil
 		}
 
 		decMsg := &Message{}
-		newVal, err := decMsg.FromPayload(payload, &h, validateFn)
+
+		if err := decMsg.FromPayload(payload); err != nil {
+			t.Fatalf("have %v, want nil", err)
+		}
+		newVal, err := decMsg.Validate(validateFn, &h)
 		if err != nil {
 			t.Fatalf("have %v, want nil", err)
 		}
-
 		if !reflect.DeepEqual(val.String(), (*newVal).String()) {
 			t.Errorf("Validators are not the same: have %v, want %v", newVal, val)
+		}
+	})
+
+	t.Run("incorrect previous block given, panic", func(t *testing.T) {
+		count := 0
+		for i := uint64(0); i < 50; i++ {
+			if i == 23 {
+				continue
+			}
+			member := types.CommitteeMember{common.HexToAddress("0x1234567890"), big.NewInt(1)}
+
+			msg := createPrevote(t, common.Hash{}, 1, new(big.Int).SetUint64(24), member)
+			payload := msg.Payload()
+
+			validateFn := func(previousHeader *types.Header, data []byte, sig []byte) (common.Address, error) {
+				return member.Address, nil
+			}
+			lastHeader := &types.Header{Number: new(big.Int).SetUint64(i), Committee: []types.CommitteeMember{member}}
+			decMsg := &Message{}
+			if err := decMsg.FromPayload(payload); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						count += 1
+					}
+				}()
+				_, _ = decMsg.Validate(validateFn, lastHeader)
+			}()
+		}
+		if count != 49 {
+			t.Fatal("panic was expected")
 		}
 	})
 }

--- a/consensus/tendermint/core/precommit_test.go
+++ b/consensus/tendermint/core/precommit_test.go
@@ -85,10 +85,7 @@ func TestSendPrecommit(t *testing.T) {
 		backendMock.EXPECT().Sign(gomock.Any()).Return([]byte{0x1}, nil)
 		backendMock.EXPECT().Sign(gomock.Eq(payloadNoSig)).Return([]byte{0x1}, nil)
 
-		payload, err := expectedMsg.Payload()
-		if err != nil {
-			t.Fatalf("Expected nil, got %v", err)
-		}
+		payload := expectedMsg.Payload()
 
 		backendMock.EXPECT().Broadcast(gomock.Any(), gomock.Any(), payload)
 
@@ -152,10 +149,7 @@ func TestSendPrecommit(t *testing.T) {
 		backendMock.EXPECT().Sign(gomock.Any()).Return([]byte{0x1}, errors.New("seal sign error"))
 		backendMock.EXPECT().Sign(payloadNoSig).Return([]byte{0x1}, nil)
 
-		payload, err := expectedMsg.Payload()
-		if err != nil {
-			t.Fatalf("Expected nil, got %v", err)
-		}
+		payload := expectedMsg.Payload()
 
 		backendMock.EXPECT().Broadcast(gomock.Any(), gomock.Any(), payload)
 

--- a/consensus/tendermint/core/prevote_test.go
+++ b/consensus/tendermint/core/prevote_test.go
@@ -59,10 +59,7 @@ func TestSendPrevote(t *testing.T) {
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().Sign(gomock.Any()).Return([]byte{0x1}, nil)
 
-		payload, err := expectedMsg.Payload()
-		if err != nil {
-			t.Fatalf("Expected nil, got %v", err)
-		}
+		payload := expectedMsg.Payload()
 
 		backendMock.EXPECT().Broadcast(gomock.Any(), gomock.Any(), payload)
 
@@ -215,10 +212,7 @@ func TestHandlePrevote(t *testing.T) {
 			Signature:     []byte{0x1},
 			power:         1,
 		}
-		payload, err := msg.Payload()
-		if err != nil {
-			t.Fatalf("Expected nil, got %v", err)
-		}
+		payload := msg.Payload()
 
 		backendMock.EXPECT().Broadcast(context.Background(), gomock.Any(), payload)
 
@@ -282,10 +276,7 @@ func TestHandlePrevote(t *testing.T) {
 			power:         1,
 		}
 
-		payload, err := msg.Payload()
-		if err != nil {
-			t.Fatalf("Expected nil, got %v", err)
-		}
+		payload := msg.Payload()
 
 		backendMock.EXPECT().Broadcast(context.Background(), gomock.Any(), payload)
 

--- a/consensus/tendermint/core/propose.go
+++ b/consensus/tendermint/core/propose.go
@@ -110,9 +110,7 @@ func (c *core) handleProposal(ctx context.Context, msg *Message) error {
 		if err == consensus.ErrFutureBlock {
 			c.stopFutureProposalTimer()
 			c.futureProposalTimer = time.AfterFunc(duration, func() {
-				_, sender, _ := c.committeeSet().GetByAddress(msg.Address)
 				c.sendEvent(backlogEvent{
-					src: sender,
 					msg: msg,
 				})
 			})

--- a/consensus/tendermint/core/propose_test.go
+++ b/consensus/tendermint/core/propose_test.go
@@ -48,10 +48,7 @@ func TestSendPropose(t *testing.T) {
 			t.Fatalf("Expected nil, got %v", err)
 		}
 
-		payload, err := expectedMsg.Payload()
-		if err != nil {
-			t.Fatalf("Expected nil, got %v", err)
-		}
+		payload := expectedMsg.Payload()
 
 		testCommittee := types.Committee{
 			types.CommitteeMember{
@@ -182,7 +179,7 @@ func TestHandleProposal(t *testing.T) {
 		defer ctrl.Finish()
 
 		addr := common.HexToAddress("0x0123456789")
-		sender := types.CommitteeMember{Address: addr, VotingPower: big.NewInt(1)}
+
 		block := types.NewBlockWithHeader(&types.Header{
 			Number: big.NewInt(1),
 		})
@@ -244,13 +241,9 @@ func TestHandleProposal(t *testing.T) {
 			t.Fatalf("Expected <nil>, got %v", err)
 		}
 
-		payload, err := preVoteMsg.Payload()
-		if err != nil {
-			t.Fatalf("Expected <nil>, got %v", err)
-		}
+		payload := preVoteMsg.Payload()
 
 		event := backlogEvent{
-			src: sender,
 			msg: msg,
 		}
 
@@ -411,10 +404,7 @@ func TestHandleProposal(t *testing.T) {
 			t.Fatalf("Expected <nil>, got %v", err)
 		}
 
-		payload, err := preVoteMsg.Payload()
-		if err != nil {
-			t.Fatalf("Expected <nil>, got %v", err)
-		}
+		payload := preVoteMsg.Payload()
 
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().VerifyProposal(*decProposal.ProposalBlock)
@@ -509,10 +499,8 @@ func TestHandleProposal(t *testing.T) {
 			t.Fatalf("Expected <nil>, got %v", err)
 		}
 
-		payload, err := preVoteMsg.Payload()
-		if err != nil {
-			t.Fatalf("Expected <nil>, got %v", err)
-		}
+		payload := preVoteMsg.Payload()
+
 		messages.getOrCreate(1).AddPrevote(block.Hash(), *preVoteMsg)
 
 		backendMock := NewMockBackend(ctrl)

--- a/consensus/tendermint/core/upon_condition_test.go
+++ b/consensus/tendermint/core/upon_condition_test.go
@@ -333,7 +333,7 @@ func TestNewProposal(t *testing.T) {
 		backendMock.EXPECT().Sign(prevoteMsgRLPNoSig).Return(prevoteMsg.Signature, nil)
 		backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), prevoteMsgRLPWithSig).Return(nil)
 
-		err := c.handleCheckedMsg(context.Background(), invalidMsg, members[currentRound])
+		err := c.handleCheckedMsg(context.Background(), invalidMsg)
 		assert.Error(t, err, "expected an error for invalid proposal")
 		assert.Equal(t, currentHeight, c.Height())
 		assert.Equal(t, currentRound, c.Round())
@@ -365,7 +365,7 @@ func TestNewProposal(t *testing.T) {
 		backendMock.EXPECT().Sign(prevoteMsgRLPNoSig).Return(prevoteMsg.Signature, nil)
 		backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), prevoteMsgRLPWithSig).Return(nil)
 
-		err := c.handleCheckedMsg(context.Background(), proposalMsg, members[currentRound])
+		err := c.handleCheckedMsg(context.Background(), proposalMsg)
 		assert.NoError(t, err)
 		assert.Equal(t, currentHeight, c.Height())
 		assert.Equal(t, currentRound, c.Round())
@@ -400,7 +400,7 @@ func TestNewProposal(t *testing.T) {
 		backendMock.EXPECT().Sign(prevoteMsgRLPNoSig).Return(prevoteMsg.Signature, nil)
 		backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), prevoteMsgRLPWithSig).Return(nil)
 
-		err := c.handleCheckedMsg(context.Background(), proposalMsg, members[currentRound])
+		err := c.handleCheckedMsg(context.Background(), proposalMsg)
 		assert.NoError(t, err)
 		assert.Equal(t, currentHeight, c.Height())
 		assert.Equal(t, currentRound, c.Round())
@@ -438,7 +438,7 @@ func TestNewProposal(t *testing.T) {
 		backendMock.EXPECT().Sign(prevoteMsgRLPNoSig).Return(prevoteMsg.Signature, nil)
 		backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), prevoteMsgRLPWithSig).Return(nil)
 
-		err := c.handleCheckedMsg(context.Background(), proposalMsg, members[currentRound])
+		err := c.handleCheckedMsg(context.Background(), proposalMsg)
 		assert.NoError(t, err)
 		assert.Equal(t, currentHeight, c.Height())
 		assert.Equal(t, currentRound, c.Round())
@@ -491,7 +491,7 @@ func TestOldProposal(t *testing.T) {
 		backendMock.EXPECT().Sign(prevoteMsgRLPNoSig).Return(prevoteMsg.Signature, nil)
 		backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), prevoteMsgRLPWithSig).Return(nil)
 
-		err := c.handleCheckedMsg(context.Background(), proposalMsg, members[currentRound])
+		err := c.handleCheckedMsg(context.Background(), proposalMsg)
 		assert.NoError(t, err)
 		assert.Equal(t, currentHeight, c.Height())
 		assert.Equal(t, currentRound, c.Round())
@@ -532,7 +532,7 @@ func TestOldProposal(t *testing.T) {
 		backendMock.EXPECT().Sign(prevoteMsgRLPNoSig).Return(prevoteMsg.Signature, nil)
 		backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), prevoteMsgRLPWithSig).Return(nil)
 
-		err := c.handleCheckedMsg(context.Background(), proposalMsg, members[currentRound])
+		err := c.handleCheckedMsg(context.Background(), proposalMsg)
 		assert.NoError(t, err)
 		assert.Equal(t, currentHeight, c.Height())
 		assert.Equal(t, currentRound, c.Round())
@@ -574,7 +574,7 @@ func TestOldProposal(t *testing.T) {
 		backendMock.EXPECT().Sign(prevoteMsgRLPNoSig).Return(prevoteMsg.Signature, nil)
 		backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), prevoteMsgRLPWithSig).Return(nil)
 
-		err := c.handleCheckedMsg(context.Background(), proposalMsg, members[currentRound])
+		err := c.handleCheckedMsg(context.Background(), proposalMsg)
 		assert.NoError(t, err)
 		assert.Equal(t, currentHeight, c.Height())
 		assert.Equal(t, currentRound, c.Round())
@@ -690,7 +690,7 @@ func TestOldProposal(t *testing.T) {
 		backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), prevoteMsgRLPWithSig).Return(nil)
 
 		// now we handle new round's proposal with round_p > vr on value v.
-		err := c.handleCheckedMsg(context.Background(), proposalMsg, members[currentRound])
+		err := c.handleCheckedMsg(context.Background(), proposalMsg)
 		assert.NoError(t, err)
 
 		// check timer was stopped after receiving the proposal
@@ -699,8 +699,8 @@ func TestOldProposal(t *testing.T) {
 		// now we receive the last old round's prevote MSG to get quorum prevote on vr for value v.
 		// the old round's prevote is accepted into the round state which now have the line 28 condition satisfied.
 		// now to take the action of line 28 which was not align with pseudo code before.
-		sender := 0
-		err = c.handleCheckedMsg(context.Background(), prevoteMsg, members[sender])
+
+		err = c.handleCheckedMsg(context.Background(), prevoteMsg)
 		assert.NoError(t, err)
 		assert.Equal(t, currentHeight, c.Height())
 		assert.Equal(t, currentRound, c.Round())
@@ -742,7 +742,7 @@ func TestPrevoteTimeout(t *testing.T) {
 		c.curRoundMessages.AddPrevote(generateBlock(currentHeight).Hash(), Message{Address: members[3].Address, Code: msgPrevote, power: 1})
 
 		assert.False(t, c.prevoteTimeout.timerStarted())
-		err := c.handleCheckedMsg(context.Background(), prevoteMsg, members[sender])
+		err := c.handleCheckedMsg(context.Background(), prevoteMsg)
 		assert.NoError(t, err)
 		assert.True(t, c.prevoteTimeout.timerStarted())
 
@@ -779,13 +779,13 @@ func TestPrevoteTimeout(t *testing.T) {
 
 		assert.False(t, c.prevoteTimeout.timerStarted())
 
-		err := c.handleCheckedMsg(context.Background(), prevote1Msg, members[sender1])
+		err := c.handleCheckedMsg(context.Background(), prevote1Msg)
 		assert.NoError(t, err)
 		assert.True(t, c.prevoteTimeout.timerStarted())
 
 		timeNow := time.Now()
 
-		err = c.handleCheckedMsg(context.Background(), prevote2Msg, members[sender2])
+		err = c.handleCheckedMsg(context.Background(), prevote2Msg)
 		assert.NoError(t, err)
 		assert.True(t, c.prevoteTimeout.timerStarted())
 		assert.True(t, c.prevoteTimeout.start.Before(timeNow))
@@ -892,7 +892,7 @@ func TestQuorumPrevote(t *testing.T) {
 			backendMock.EXPECT().Sign(precommitMsgRLPNoSig).Return(precommitMsg.Signature, nil)
 			backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), precommitMsgRLPWithSig).Return(nil)
 
-			err := c.handleCheckedMsg(context.Background(), prevoteMsg, members[sender])
+			err := c.handleCheckedMsg(context.Background(), prevoteMsg)
 			assert.NoError(t, err)
 
 			assert.Equal(t, proposal.ProposalBlock, c.lockedValue)
@@ -900,7 +900,7 @@ func TestQuorumPrevote(t *testing.T) {
 			assert.Equal(t, precommit, c.step)
 
 		} else if currentStep == precommit {
-			err := c.handleCheckedMsg(context.Background(), prevoteMsg, members[sender])
+			err := c.handleCheckedMsg(context.Background(), prevoteMsg)
 			assert.NoError(t, err)
 
 			assert.Equal(t, proposal.ProposalBlock, c.validValue)
@@ -944,7 +944,7 @@ func TestQuorumPrevote(t *testing.T) {
 			backendMock.EXPECT().Sign(precommitMsgRLPNoSig).Return(precommitMsg.Signature, nil)
 			backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), precommitMsgRLPWithSig).Return(nil)
 
-			err := c.handleCheckedMsg(context.Background(), prevoteMsg1, members[sender1])
+			err := c.handleCheckedMsg(context.Background(), prevoteMsg1)
 			assert.NoError(t, err)
 
 			assert.Equal(t, proposal.ProposalBlock, c.lockedValue)
@@ -952,7 +952,7 @@ func TestQuorumPrevote(t *testing.T) {
 			assert.Equal(t, precommit, c.step)
 
 		} else if currentStep == precommit {
-			err := c.handleCheckedMsg(context.Background(), prevoteMsg1, members[sender1])
+			err := c.handleCheckedMsg(context.Background(), prevoteMsg1)
 			assert.NoError(t, err)
 
 			assert.Equal(t, proposal.ProposalBlock, c.validValue)
@@ -965,7 +965,7 @@ func TestQuorumPrevote(t *testing.T) {
 		lockedRoundBefore := c.lockedRound
 		validRoundBefore := c.validRound
 
-		err := c.handleCheckedMsg(context.Background(), prevoteMsg2, members[sender2])
+		err := c.handleCheckedMsg(context.Background(), prevoteMsg2)
 		assert.NoError(t, err)
 
 		assert.Equal(t, currentHeight, c.Height())
@@ -1009,7 +1009,7 @@ func TestQuorumPrevoteNil(t *testing.T) {
 	backendMock.EXPECT().Sign(precommitMsgRLPNoSig).Return(precommitMsg.Signature, nil)
 	backendMock.EXPECT().Broadcast(context.Background(), committeeSet.Committee(), precommitMsgRLPWithSig).Return(nil)
 
-	err := c.handleCheckedMsg(context.Background(), prevoteMsg, members[sender])
+	err := c.handleCheckedMsg(context.Background(), prevoteMsg)
 	assert.NoError(t, err)
 
 	assert.Equal(t, currentHeight, c.Height())
@@ -1048,7 +1048,7 @@ func TestPrecommitTimeout(t *testing.T) {
 		c.curRoundMessages.AddPrecommit(generateBlock(currentHeight).Hash(), Message{Address: members[3].Address, Code: msgPrecommit, power: 1})
 
 		assert.False(t, c.precommitTimeout.timerStarted())
-		err := c.handleCheckedMsg(context.Background(), precommitMsg, members[sender])
+		err := c.handleCheckedMsg(context.Background(), precommitMsg)
 		assert.NoError(t, err)
 		assert.True(t, c.precommitTimeout.timerStarted())
 
@@ -1086,13 +1086,13 @@ func TestPrecommitTimeout(t *testing.T) {
 
 		assert.False(t, c.precommitTimeout.timerStarted())
 
-		err := c.handleCheckedMsg(context.Background(), precommit1Msg, members[sender1])
+		err := c.handleCheckedMsg(context.Background(), precommit1Msg)
 		assert.NoError(t, err)
 		assert.True(t, c.precommitTimeout.timerStarted())
 
 		timeNow := time.Now()
 
-		err = c.handleCheckedMsg(context.Background(), precommit2Msg, members[sender2])
+		err = c.handleCheckedMsg(context.Background(), precommit2Msg)
 		assert.NoError(t, err)
 		assert.True(t, c.precommitTimeout.timerStarted())
 		assert.True(t, c.precommitTimeout.start.Before(timeNow))
@@ -1201,7 +1201,7 @@ func TestQuorumPrecommit(t *testing.T) {
 	// TODO: investigate what order should be on committed seals
 	backendMock.EXPECT().Commit(proposal.ProposalBlock, currentRound, gomock.Any())
 
-	err := c.handleCheckedMsg(context.Background(), precommitMsg, members[sender])
+	err := c.handleCheckedMsg(context.Background(), precommitMsg)
 	assert.NoError(t, err)
 
 	newCommitteeSet, err := newRoundRobinSet(committeeSet.Committee(), members[currentRound].Address)
@@ -1265,10 +1265,10 @@ func TestFutureRoundChange(t *testing.T) {
 		c.setStep(currentStep)
 		c.setCommitteeSet(committeeSet)
 
-		err := c.handleCheckedMsg(context.Background(), msg1, sender1)
+		err := c.handleCheckedMsg(context.Background(), msg1)
 		assert.Equal(t, errFutureRoundMessage, err)
 
-		err = c.handleCheckedMsg(context.Background(), msg2, sender2)
+		err = c.handleCheckedMsg(context.Background(), msg2)
 		assert.Equal(t, errFutureRoundMessage, err)
 
 		assert.Equal(t, currentHeight, c.Height())
@@ -1299,10 +1299,10 @@ func TestFutureRoundChange(t *testing.T) {
 		c.setStep(currentStep)
 		c.setCommitteeSet(committeeSet)
 
-		err := c.handleCheckedMsg(context.Background(), prevoteMsg, sender1)
+		err := c.handleCheckedMsg(context.Background(), prevoteMsg)
 		assert.Equal(t, errFutureRoundMessage, err)
 
-		err = c.handleCheckedMsg(context.Background(), precommitMsg, sender1)
+		err = c.handleCheckedMsg(context.Background(), precommitMsg)
 		assert.Equal(t, errFutureRoundMessage, err)
 
 		assert.Equal(t, currentHeight, c.Height())
@@ -1341,9 +1341,6 @@ func TestHandleMessage(t *testing.T) {
 		msg.Signature, err = crypto.Sign(crypto.Keccak256(msgRlpNoSig), key2)
 		assert.NoError(t, err)
 
-		msgRlpWithSig, err := msg.Payload()
-		assert.NoError(t, err)
-
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -1353,7 +1350,7 @@ func TestHandleMessage(t *testing.T) {
 		core := New(backendMock, config.DefaultConfig())
 		core.setCommitteeSet(committeeSet)
 		core.lastHeader = prevBlock.Header()
-		err = core.handleMsg(context.Background(), msgRlpWithSig)
+		err = core.handleMsg(context.Background(), msg)
 
 		assert.Error(t, err, "unauthorised sender, sender is not is committees set")
 	})
@@ -1369,9 +1366,6 @@ func TestHandleMessage(t *testing.T) {
 		msg.Signature, err = crypto.Sign(crypto.Keccak256(msgRlpNoSig), key1)
 		assert.NoError(t, err)
 
-		msgRlpWithSig, err := msg.Payload()
-		assert.NoError(t, err)
-
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -1381,7 +1375,7 @@ func TestHandleMessage(t *testing.T) {
 		core := New(backendMock, config.DefaultConfig())
 		core.setCommitteeSet(committeeSet)
 		core.lastHeader = prevBlock.Header()
-		err = core.handleMsg(context.Background(), msgRlpWithSig)
+		err = core.handleMsg(context.Background(), msg)
 
 		assert.Error(t, err, "unauthorised sender, sender is not the signer of the message")
 	})
@@ -1393,8 +1387,6 @@ func TestHandleMessage(t *testing.T) {
 		assert.NoError(t, err)
 
 		msg := &Message{Address: key1PubAddr, Code: uint64(rand.Intn(3)), Msg: []byte("random message2"), Signature: sig}
-		msgRlpWithSig, err := msg.Payload()
-		assert.NoError(t, err)
 
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -1405,7 +1397,7 @@ func TestHandleMessage(t *testing.T) {
 		core := New(backendMock, config.DefaultConfig())
 		core.setCommitteeSet(committeeSet)
 		core.lastHeader = prevBlock.Header()
-		err = core.handleMsg(context.Background(), msgRlpWithSig)
+		err = core.handleMsg(context.Background(), msg)
 
 		assert.Error(t, err, "malicious sender sends different signature to signature of message")
 	})
@@ -1423,8 +1415,7 @@ func prepareProposal(t *testing.T, currentRound int64, proposalHeight *big.Int, 
 	proposalMsg.Signature, err = sign(proposalMsgRLPNoSig, privateKey)
 	assert.NoError(t, err)
 
-	proposalMsgRLPWithSig, err := proposalMsg.Payload()
-	assert.NoError(t, err)
+	proposalMsgRLPWithSig := proposalMsg.Payload()
 
 	return proposalMsg, proposalMsgRLPNoSig, proposalMsgRLPWithSig
 }
@@ -1444,8 +1435,7 @@ func prepareVote(t *testing.T, step uint64, round int64, height *big.Int, blockH
 	voteMsg.Signature, err = sign(voteMsgRLPNoSig, privateKey)
 	assert.NoError(t, err)
 
-	voteMsgRLPWithSig, err := voteMsg.Payload()
-	assert.NoError(t, err)
+	voteMsgRLPWithSig := voteMsg.Payload()
 
 	return voteMsg, voteMsgRLPNoSig, voteMsgRLPWithSig
 }


### PR DESCRIPTION
closes https://github.com/clearmatics/autonity/issues/651

- introduce the _untrusted backlog buffer_, that will contain future height messages to be correctly verified when the state reach the appropriate height.
- some refactoring to accommodate that.
