### PR TITLE
Unlock accounts at autonity start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,13 +111,15 @@ test-contracts:
 	@npm list truffle > /dev/null || npm install truffle
 	@npm list web3 > /dev/null || npm install web3
 	@cd contracts/autonity/contract/test/autonity/ && rm -Rdf ./data && ./autonity-start.sh &
-	@# Autonity can take some time to start listening on port 8545 so we allow multiple connection attempts.
+	@# Autonity can take some time to start up so we ping its port till we see it is listening.
+	@# The -z option to netcat exits with 0 only if the port at the given addresss is listening.
 	@for x in {1..10}; do \
-		sleep 2 ; \
-		./build/bin/autonity --exec "web3.personal.unlockAccount(eth.accounts[0], 'test', 36000)" attach http://localhost:8545 ; \
-		if [ $$? -eq 0 ] ; then \
-			break ; \
-		fi ; \
+		nc -z localhost 8545 ; \
+	    if [ $$? -eq 0 ] ; then \
+	        break ; \
+	    fi ; \
+		echo waiting 2 more seconds for autonity to start ; \
+	    sleep 2 ; \
 	done
 	@cd contracts/autonity/contract/ && $(NPMBIN)/truffle test && cd -
 

--- a/contracts/autonity/contract/migrations/1_initial_migration.js
+++ b/contracts/autonity/contract/migrations/1_initial_migration.js
@@ -4,20 +4,6 @@ const Web3 = require('web3');
 const TruffleConfig = require('../truffle-config');
 
 module.exports = function(deployer, network, accounts) {
-  const config = TruffleConfig.networks[network];
-  const web3 = new Web3(new Web3.providers.HttpProvider('http://' + config.host + ':' + config.port));
-
-  console.log('>> Unlocking account ' + accounts);
-  web3.eth.personal.unlockAccount(accounts[0], "test", 36000);
-  web3.eth.personal.unlockAccount(accounts[1], "test", 36000);
-  web3.eth.personal.unlockAccount(accounts[2], "test", 36000);
-  web3.eth.personal.unlockAccount(accounts[3], "test", 36000);
-  web3.eth.personal.unlockAccount(accounts[4], "test", 36000);
-  web3.eth.personal.unlockAccount(accounts[5], "test", 36000);
-  web3.eth.personal.unlockAccount(accounts[6], "test", 36000);
-  web3.eth.personal.unlockAccount(accounts[7], "test", 36000);
-  web3.eth.personal.unlockAccount(accounts[8], "test", 36000);
-
   console.log('>> Deploying migration');
   deployer.deploy(Migrations);
 };

--- a/contracts/autonity/contract/test/autonity/autonity-start.sh
+++ b/contracts/autonity/contract/test/autonity/autonity-start.sh
@@ -34,5 +34,7 @@ $AUTONITY \
   --syncmode "full" \
   --mine \
   --allow-insecure-unlock \
+  --unlock 0x850c1eb8d190e05845ad7f84ac95a318c8aab07f,0x4ad219b58a5b46a1d9662beaa6a70db9f570dea5,0x4b07239bd581d21aefcdee0c6db38070f9a5fd2d,0xc443c6c6ae98f5110702921138d840e77da67702,0x09428e8674496e2d1e965402f33a9520c5fcbbe2,0x64852003fc0b84d6c49c5cb3dfcd17922affddc1,0x4839950a5f07d6d6cd82f933d1de8574c48d6e74,0x160bc705bf2e5871557722c9332cfa185c02b765,0xe12b43B69E57eD6ACdd8721Eb092BF7c8D41Df41,0xDE03B7806f885Ae79d2aa56568b77caDB0de073E \
+  --password password \
   --miner.threads 1 \
   --verbosity 1

--- a/contracts/autonity/contract/test/autonity/password
+++ b/contracts/autonity/contract/test/autonity/password
@@ -1,0 +1,10 @@
+test
+test
+test
+test
+test
+test
+test
+test
+test
+test


### PR DESCRIPTION
This commit ensures that we start autonity with flags to unlock required
accounts as opposed to requesting account unlocks via the autonity
console.

It looks like when requesting an account unlock from the console, the
console returns while unlocking continues in the background, so you
can't know when the account will be ready.

It also looks like a similar thing occurs when requesting unlocks via
the commandline, because the ethereum node is started before accounts
are unlocked (see link below), so this is by no means guaranteed to
solve the issue. But it seems to have stopped the failure seen in #626
from occurring and so is an improvement.

https://github.com/clearmatics/autonity/blob/a5d4c6bd8d607a413c41220f0812cdd3f07adece/cmd/autonity/main.go#L323-L327

Fixes #626