### PR TITLE
Combine Autonity init-chain and start-up.

### DIFF
--- a/cmd/autonity/chaincmd.go
+++ b/cmd/autonity/chaincmd.go
@@ -199,14 +199,21 @@ Use "ethereum dump 0" to dump the genesis block.`,
 // initGenesis will initialise the given JSON format genesis file and writes it as
 // the zero'd block (i.e. genesis) or will fail hard if it can't succeed.
 func initGenesis(ctx *cli.Context) error {
-	// Make sure we have a valid genesis JSON
+	// If user does not specify a genesis file on genesis flag, start node from current data dir.
 	if !ctx.GlobalIsSet(utils.InitGenesisFlag.Name) {
-		log.Info("Genesis flag is not set, start node directly.")
-		log.Info("In case of 1st time start, please start client with setting genesis flag, " +
+		log.Info("genesis flag is not set, start node directly from data dir.")
+		log.Info("In case of 1st time start, please start client with setting --genesis flag, " +
 			"the client will auto init genesis block before attach to network.")
 		return nil
 	}
+
+	// If there is no genesis block presented, init a genesis block with genesis file,
+	// otherwise it checks if genesis block is compatible and matched with genesis file
+	// and return error if they are not, the error would terminate autonity client.
+
+	// Make sure we have a valid genesis JSON.
 	genesisPath := ctx.GlobalString(utils.InitGenesisFlag.Name)
+	log.Info("Trying to init genesis block with genesis file", "file", genesisPath)
 	if len(genesisPath) == 0 {
 		utils.Fatalf("Must supply path to genesis JSON file")
 		return fmt.Errorf("must supply path to genesis JSON file")

--- a/cmd/autonity/chaincmd.go
+++ b/cmd/autonity/chaincmd.go
@@ -45,22 +45,6 @@ import (
 )
 
 var (
-	initCommand = cli.Command{
-		Action:    utils.MigrateFlags(initGenesis),
-		Name:      "init",
-		Usage:     "Bootstrap and initialize a new genesis block",
-		ArgsUsage: "<genesisPath>",
-		Flags: []cli.Flag{
-			utils.DataDirFlag,
-		},
-		Category: "BLOCKCHAIN COMMANDS",
-		Description: `
-The init command initializes a new genesis block and definition for the network.
-This is a destructive action and changes the network in which you will be
-participating.
-
-It expects the genesis file as argument.`,
-	}
 	dumpGenesisCommand = cli.Command{
 		Action:    utils.MigrateFlags(dumpGenesis),
 		Name:      "dumpgenesis",
@@ -216,29 +200,41 @@ Use "ethereum dump 0" to dump the genesis block.`,
 // the zero'd block (i.e. genesis) or will fail hard if it can't succeed.
 func initGenesis(ctx *cli.Context) error {
 	// Make sure we have a valid genesis JSON
-	genesisPath := ctx.Args().First()
+	if !ctx.GlobalIsSet(utils.InitGenesisFlag.Name) {
+		log.Info("Genesis flag is not set, start node directly.")
+		log.Info("In case of 1st time start, please start client with setting genesis flag, " +
+			"the client will auto init genesis block before attach to network.")
+		return nil
+	}
+	genesisPath := ctx.GlobalString(utils.InitGenesisFlag.Name)
 	if len(genesisPath) == 0 {
 		utils.Fatalf("Must supply path to genesis JSON file")
+		return fmt.Errorf("must supply path to genesis JSON file")
 	}
 	file, err := os.Open(genesisPath)
 	if err != nil {
 		utils.Fatalf("Failed to read genesis file: %v", err)
+		return err
 	}
 	defer file.Close()
 
 	genesis := new(core.Genesis)
 	if err := json.NewDecoder(file).Decode(genesis); err != nil {
 		utils.Fatalf("invalid genesis file: %v", err)
+		return err
 	}
 	// Make AutonityContract and Tendermint consensus mandatory for the time being.
 	if genesis.Config == nil {
 		utils.Fatalf("No Autonity Contract and Tendermint configs section in genesis")
+		return fmt.Errorf("no Autonity Contract and Tendermint configs section in genesis")
 	}
 	if genesis.Config.AutonityContractConfig == nil {
 		utils.Fatalf("No Autonity Contract config section in genesis")
+		return fmt.Errorf("no Autonity Contract config section in genesis")
 	}
 	if genesis.Config.Tendermint == nil {
 		utils.Fatalf("No Tendermint config section in genesis")
+		return fmt.Errorf("no Tendermint config section in genesis")
 	}
 
 	if err := genesis.Config.AutonityContractConfig.Prepare(); err != nil {
@@ -256,10 +252,12 @@ func initGenesis(ctx *cli.Context) error {
 		chaindb, err := stack.OpenDatabase(name, 0, 0, "")
 		if err != nil {
 			utils.Fatalf("Failed to open database: %v", err)
+			return err
 		}
 		_, hash, err := core.SetupGenesisBlock(chaindb, genesis)
 		if err != nil {
 			utils.Fatalf("Failed to write genesis block: %v", err)
+			return err
 		}
 		chaindb.Close()
 		log.Info("Successfully wrote genesis state", "database", name, "hash", hash)

--- a/cmd/autonity/main.go
+++ b/cmd/autonity/main.go
@@ -202,7 +202,6 @@ func init() {
 	app.Copyright = "Copyright 2013-2020 The go-ethereum Authors"
 	app.Commands = []cli.Command{
 		// See chaincmd.go:
-		initCommand,
 		importCommand,
 		exportCommand,
 		importPreimagesCommand,
@@ -241,7 +240,12 @@ func init() {
 	app.Flags = append(app.Flags, metricsFlags...)
 
 	app.Before = func(ctx *cli.Context) error {
-		return debug.Setup(ctx)
+		err := debug.Setup(ctx)
+		if err != nil {
+			return err
+		}
+		// check genesis flag and try to init genesis block, error will stop the app execution.
+		return initGenesis(ctx)
 	}
 	app.After = func(ctx *cli.Context) error {
 		debug.Exit()

--- a/cmd/autonity/main.go
+++ b/cmd/autonity/main.go
@@ -64,6 +64,7 @@ var (
 		utils.LegacyBootnodesV4Flag,
 		utils.LegacyBootnodesV5Flag,
 		utils.DataDirFlag,
+		utils.InitGenesisFlag,
 		utils.AncientFlag,
 		utils.KeyStoreDirFlag,
 		utils.ExternalSignerFlag,

--- a/cmd/autonity/main.go
+++ b/cmd/autonity/main.go
@@ -245,7 +245,7 @@ func init() {
 		if err != nil {
 			return err
 		}
-		// check genesis flag and try to init genesis block, error will stop the app execution.
+		// Try to init chain before autonity start up. Any error from initGenesis would terminate node start up.
 		return initGenesis(ctx)
 	}
 	app.After = func(ctx *cli.Context) error {

--- a/cmd/autonity/usage.go
+++ b/cmd/autonity/usage.go
@@ -66,6 +66,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Name: "ETHEREUM",
 		Flags: []cli.Flag{
 			configFileFlag,
+			utils.InitGenesisFlag,
 			utils.DataDirFlag,
 			utils.AncientFlag,
 			utils.KeyStoreDirFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -134,6 +134,11 @@ func printHelp(out io.Writer, templ string, data interface{}) {
 
 var (
 	// General settings
+	InitGenesisFlag = cli.StringFlag{
+		Name:  "genesis",
+		Usage: "Path to the genesis json file",
+		Value: "",
+	}
 	DataDirFlag = DirectoryFlag{
 		Name:  "datadir",
 		Usage: "Data directory for the databases and keystore",

--- a/contracts/autonity/contract/test/autonity/autonity-start.sh
+++ b/contracts/autonity/contract/test/autonity/autonity-start.sh
@@ -19,7 +19,7 @@ RPC_API="tendermint,console,eth,web3,admin,debug,miner,personal,txpool,net"
 # start the node with the keystore and nodekey
 echo "Autonity START"
 $AUTONITY \
-  --genesis "./genesis-tendermint.json" \
+  --genesis genesis-tendermint.json \
   --datadir $DATADIR \
   --nodekey $NODEKEY \
   --keystore $KEYSTORE \

--- a/contracts/autonity/contract/test/autonity/autonity-start.sh
+++ b/contracts/autonity/contract/test/autonity/autonity-start.sh
@@ -19,7 +19,7 @@ RPC_API="tendermint,console,eth,web3,admin,debug,miner,personal,txpool,net"
 # start the node with the keystore and nodekey
 echo "Autonity START"
 $AUTONITY \
-  --genesis genesis-tendermint.json \
+  --genesis "./genesis-tendermint.json" \
   --datadir $DATADIR \
   --nodekey $NODEKEY \
   --keystore $KEYSTORE \

--- a/contracts/autonity/contract/test/autonity/autonity-start.sh
+++ b/contracts/autonity/contract/test/autonity/autonity-start.sh
@@ -13,12 +13,13 @@ RPC_ADDR=127.0.0.1
 RPC_API="tendermint,console,eth,web3,admin,debug,miner,personal,txpool,net"
 
 # init the data directory
-echo "Autonity INIT $RPC_ADDR"
-$AUTONITY init --datadir $DATADIR genesis-tendermint.json
+# echo "Autonity INIT $RPC_ADDR"
+# $AUTONITY init --datadir $DATADIR genesis-tendermint.json
 
 # start the node with the keystore and nodekey
 echo "Autonity START"
 $AUTONITY \
+  --genesis genesis-tendermint.json \
   --datadir $DATADIR \
   --nodekey $NODEKEY \
   --keystore $KEYSTORE \


### PR DESCRIPTION
To close issue: https://github.com/clearmatics/autonity/issues/682
This PR is an enhancement of autonity client, it does not need user to execute a seperate init command to init the chain data before node start. By specifying a flag: --genesis with your genesis json file, client will try to init genesis the chain data for user, and then start node. You don't need to run extra command to start node anymore. 