### PR TITLE
Add support for contract RPC calls with arguments

### DIFF
--- a/accounts/abi/argument.go
+++ b/accounts/abi/argument.go
@@ -75,6 +75,15 @@ func (arguments Arguments) isTuple() bool {
 	return len(arguments) > 1
 }
 
+// isTuple returns true for non-atomic constructs, like (uint,uint) or uint[]
+func (arguments Arguments) Types() []reflect.Type {
+	var ret []reflect.Type
+	for _, a := range arguments {
+		ret = append(ret, a.Type.getType())
+	}
+	return ret
+}
+
 // Unpack performs the operation hexdata -> Go format
 func (arguments Arguments) Unpack(v interface{}, data []byte) error {
 	if len(data) == 0 {

--- a/contracts/autonity/autonity.go
+++ b/contracts/autonity/autonity.go
@@ -3,7 +3,6 @@ package autonity
 import (
 	"errors"
 	"math/big"
-	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -34,11 +33,6 @@ type Blockchainer interface {
 	ReadEnodeWhitelist() *types.Nodes
 
 	PutKeyValue(key []byte, value []byte) error
-}
-
-type ContractAPIFunc struct {
-	Fn     reflect.Value
-	ArgsIn []reflect.Type
 }
 
 type Contract struct {

--- a/contracts/autonity/autonity.go
+++ b/contracts/autonity/autonity.go
@@ -3,6 +3,7 @@ package autonity
 import (
 	"errors"
 	"math/big"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -35,7 +36,10 @@ type Blockchainer interface {
 	PutKeyValue(key []byte, value []byte) error
 }
 
-type ContractAPIFunc func() (interface{}, error)
+type ContractAPIFunc struct {
+	Fn     reflect.Value
+	ArgsIn []reflect.Type
+}
 
 type Contract struct {
 	evmProvider        EVMProvider

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -322,7 +322,7 @@ func (s *Ethereum) APIs() []rpc.API {
 		apis = append(apis, rpc.API{
 			Namespace: "autonityContract",
 			Version:   params.Version,
-			Service:   NewAutonityContractAPI(s).ContractABIMethods(),
+			Service:   NewAutonityContractAPI(s),
 			Public:    true,
 		})
 	}

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/clearmatics/autonity/contracts/autonity"
 	"reflect"
 	"runtime"
 	"strings"
@@ -57,6 +56,11 @@ type callback struct {
 	hasCtx      bool           // method's first argument is a context (not included in argTypes)
 	errPos      int            // err return idx, of -1 when method cannot return error
 	isSubscribe bool           // true if this is a subscription callback
+}
+
+// DynamicCallbacks is used for receivers with dynamic API's method to retrieve.
+type DynamicCallbacks interface {
+	Calls() map[string]reflect.Value
 }
 
 func (r *serviceRegistry) registerName(name string, rcvr interface{}) error {
@@ -117,42 +121,35 @@ func (r *serviceRegistry) subscription(service, name string) *callback {
 func suitableCallbacks(receiver reflect.Value) map[string]*callback {
 	typ := receiver.Type()
 	callbacks := make(map[string]*callback)
+	for m := 0; m < typ.NumMethod(); m++ {
+		method := typ.Method(m)
+		if method.PkgPath != "" {
+			continue // method not exported
+		}
+		cb := newCallback(receiver, method.Func)
+		if cb == nil {
+			continue // function invalid
+		}
+		name := formatName(method.Name)
+		callbacks[name] = cb
+	}
 
-	if funM, ok := receiver.Interface().(map[string]autonity.ContractAPIFunc); ok {
-		for funcName, contractFunc := range funM {
-			// Autonity contract api can change and therefore the number of functions exposed through the rpc endpoint
-			// can also change, thus a map of autonity.ContractAPIFunc is used to expose the autonity functions.
-			//
-			// The rpc service assumes a reflect.Value will be passed to Service which is of a type that has methods
-			// defined on it. This can only be achieved for static types. Golang doesn't allow for dynamically adding
-			// methods to types therefore anonymous functions must be used and by definition anonymous function can not
-			// have static methods defined on them.
-			//
-			// When creating a new callback, the function expects the type x and the method defined on x, since we
-			// cannot satisfy this condition we pass the type of the anonymous method as both the receiver and method.
-			cb := newCallback(reflect.ValueOf(contractFunc), contractFunc.Fn)
-			if cb == nil {
-				panic("autonity anonymous function cannot be converted to callback")
-			}
-			name := formatName(funcName)
-			cb.argTypes = contractFunc.ArgsIn
-			callbacks[name] = cb
-		}
-	} else {
-		for m := 0; m < typ.NumMethod(); m++ {
-			method := typ.Method(m)
-			if method.PkgPath != "" {
-				continue // method not exported
-			}
-			cb := newCallback(receiver, method.Func)
-			if cb == nil {
-				continue // function invalid
-			}
-			name := formatName(method.Name)
-			callbacks[name] = cb
-		}
+	if dyn, ok := receiver.Interface().(DynamicCallbacks); ok {
+		registerCallbacks(callbacks, receiver, dyn.Calls())
 	}
 	return callbacks
+}
+
+// registerCallbacks register new callbacks is the receiver implement DynamicCallbacks.
+func registerCallbacks(callbacks map[string]*callback, receiver reflect.Value, methods map[string]reflect.Value) {
+	for name, fn := range methods {
+		cb := newCallback(receiver, fn)
+		if cb == nil {
+			panic("can't register dynamic callback")
+		}
+		fname := formatName(name)
+		callbacks[fname] = cb
+	}
 }
 
 // newCallback turns fn (a function) into a callback object. It returns nil if the function
@@ -191,12 +188,7 @@ func (c *callback) makeArgTypes() {
 	// Skip receiver and context.Context parameter (if present).
 	firstArg := 0
 	if c.rcvr.IsValid() {
-		// Anonymous functions have no receiver therefore the total number of arguments required to call the function
-		// is one less than a method which is defined on a static type. Therefore, we need to make sure that if the
-		// receiver satisfies autonity.ContractAPIFunc we do not have off by one error, which will cause a panic.
-		if _, ok := c.rcvr.Interface().(autonity.ContractAPIFunc); !ok {
-			firstArg++
-		}
+		firstArg++
 	}
 	if fntype.NumIn() > firstArg && fntype.In(firstArg) == contextType {
 		c.hasCtx = true
@@ -214,12 +206,7 @@ func (c *callback) call(ctx context.Context, method string, args []reflect.Value
 	// Create the argument slice.
 	fullargs := make([]reflect.Value, 0, 2+len(args))
 	if c.rcvr.IsValid() {
-		// Anonymous functions have no receiver therefore the total number of arguments required to call the function
-		// is one less than a method which is defined on a static type. Therefore, we need to make sure that if the
-		// receiver satisfies autonity.ContractAPIFunc we do not have off by one error, which will cause a panic.
-		if _, ok := c.rcvr.Interface().(autonity.ContractAPIFunc); !ok {
-			fullargs = append(fullargs, c.rcvr)
-		}
+		fullargs = append(fullargs, c.rcvr)
 	}
 	if c.hasCtx {
 		fullargs = append(fullargs, reflect.ValueOf(ctx))

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -130,11 +130,12 @@ func suitableCallbacks(receiver reflect.Value) map[string]*callback {
 			//
 			// When creating a new callback, the function expects the type x and the method defined on x, since we
 			// cannot satisfy this condition we pass the type of the anonymous method as both the receiver and method.
-			cb := newCallback(reflect.ValueOf(contractFunc), reflect.ValueOf(contractFunc))
+			cb := newCallback(reflect.ValueOf(contractFunc), contractFunc.Fn)
 			if cb == nil {
 				panic("autonity anonymous function cannot be converted to callback")
 			}
 			name := formatName(funcName)
+			cb.argTypes = contractFunc.ArgsIn
 			callbacks[name] = cb
 		}
 	} else {

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -121,21 +121,22 @@ func (r *serviceRegistry) subscription(service, name string) *callback {
 func suitableCallbacks(receiver reflect.Value) map[string]*callback {
 	typ := receiver.Type()
 	callbacks := make(map[string]*callback)
-	for m := 0; m < typ.NumMethod(); m++ {
-		method := typ.Method(m)
-		if method.PkgPath != "" {
-			continue // method not exported
-		}
-		cb := newCallback(receiver, method.Func)
-		if cb == nil {
-			continue // function invalid
-		}
-		name := formatName(method.Name)
-		callbacks[name] = cb
-	}
 
 	if dyn, ok := receiver.Interface().(DynamicCallbacks); ok {
 		registerCallbacks(callbacks, receiver, dyn.Calls())
+	} else {
+		for m := 0; m < typ.NumMethod(); m++ {
+			method := typ.Method(m)
+			if method.PkgPath != "" {
+				continue // method not exported
+			}
+			cb := newCallback(receiver, method.Func)
+			if cb == nil {
+				continue // function invalid
+			}
+			name := formatName(method.Name)
+			callbacks[name] = cb
+		}
 	}
 	return callbacks
 }


### PR DESCRIPTION
- Add support for functions taking arguments.
- Some refactoring along the way, made it a bit more generic.

Example:
```
curl -X POST -H "Content-type: application/json" --data '{"jsonrpc":"2.0","method":"autonityContract_checkMember","params":["0x9b4dfa42a868cd3899f59fb22d96a155752fe1cb"],"id":2}' http://localhost:6000  | jq

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   160  100    40  100   120  40000   117k --:--:-- --:--:-- --:--:--  156k
{
  "jsonrpc": "2.0",
  "id": 2,
  "result": false
}
```