### PR TITLE
Update config on docker test framework to align with latest upstream.

### DIFF
--- a/docker_e2e_test/Dockerfile
+++ b/docker_e2e_test/Dockerfile
@@ -7,4 +7,4 @@ RUN  apt-get update && \
 COPY . .
 RUN pip3 install -r ./requirements.txt
 RUN apt-get clean
-EXPOSE 22 6000 7000 8000 9000 30303
+EXPOSE 22 6000 7000 8000 30303

--- a/docker_e2e_test/client/client.py
+++ b/docker_e2e_test/client/client.py
@@ -58,7 +58,7 @@ DEFAULT_PACKAGE_CORRUPT_RATE = 0.1  # 0.1%
 
 
 class Client(object):
-    def __init__(self, host=None, p2p_port=None, rpc_port=None, ws_port=None, graphql_port=None, net_interface=None,
+    def __init__(self, host=None, p2p_port=None, rpc_port=None, ws_port=None, net_interface=None,
                  coin_base=None, ssh_user=None, ssh_pass=None, ssh_key=None, sudo_pass=None, autonity_path=None,
                  bootnode_path=None, role=None, index=None, e_node=None):
         self.autonity_path = autonity_path
@@ -67,7 +67,6 @@ class Client(object):
         self.p2p_port = p2p_port
         self.rpc_port = rpc_port
         self.ws_port = ws_port
-        self.graphql_port = graphql_port
         self.net_interface = net_interface
         self.ssh_user = ssh_user
         self.ssh_pass = ssh_pass
@@ -142,7 +141,7 @@ class Client(object):
                    "ExecStart={} --datadir {} --nodekey {} --syncmode 'full' --port {} " \
                    "--rpcport {} --rpc --rpcaddr '0.0.0.0' --ws --wsport {} --rpccorsdomain '*' "\
                    "--rpcapi 'personal,debug,db,eth,net,web3,txpool,miner,tendermint,clique' --networkid 1991  " \
-                   "--gasprice '0' --allow-insecure-unlock --graphql --graphql.port {} " \
+                   "--gasprice '0' --allow-insecure-unlock --graphql " \
                    "--unlock 0x{} --password {} " \
                    "--debug --mine --minerthreads '1' --etherbase 0x{} --verbosity 4 --miner.gaslimit 10000000000 --miner.gastarget 100000000000 --metrics --pprof \n" \
                    "KillMode=process\n" \
@@ -154,25 +153,6 @@ class Client(object):
                    "Alias=autonity.service\n"\
                    "WantedBy=multi-user.target"
 
-        template_local = "[Unit]\n" \
-                   "Description=Clearmatics Autonity Client server\n" \
-                   "After=syslog.target network.target\n" \
-                   "[Service]\n" \
-                   "Type=simple\n" \
-                   "ExecStart={} --datadir {} --nodekey {} --syncmode 'full' --port {} " \
-                   "--rpcport {} --rpc --rpcaddr '0.0.0.0' --ws --wsport {} --rpccorsdomain '*' "\
-                   "--rpcapi 'personal,debug,db,eth,net,web3,txpool,miner,tendermint,clique' --networkid 1991  " \
-                   "--gasprice '0' --allow-insecure-unlock --graphql --graphql.port {} " \
-                   "--unlock 0x{} --password {} " \
-                   "--debug --mine --minerthreads '1' --etherbase 0x{} --verbosity 4 --miner.gaslimit 10000000000 --miner.gastarget 100000000000 --metrics --pprof \n" \
-                   "KillMode=process\n" \
-                   "KillSignal=SIGINT\n" \
-                   "TimeoutStopSec=1\n" \
-                   "Restart=on-failure\n" \
-                   "RestartSec=1s\n" \
-                   "[Install]\n" \
-                   "Alias=autonity{}.service\n"\
-                   "WantedBy=multi-user.target"
         folder = self.host
 
         print("prepare autonity systemd service file for node: %s", self.host)
@@ -182,11 +162,10 @@ class Client(object):
         p2p_port = self.p2p_port
         rpc_port = self.rpc_port
         ws_port = self.ws_port
-        graphql_port = self.graphql_port
         coin_base = self.coin_base
         password_file = KEY_PASSPHRASE_FILE.format(self.ssh_user, folder)
 
-        content = template_remote.format(bin_path, data_dir, boot_key_file, p2p_port, rpc_port, ws_port, graphql_port,
+        content = template_remote.format(bin_path, data_dir, boot_key_file, p2p_port, rpc_port, ws_port,
                                          coin_base, password_file, coin_base)
         with open("./network-data/{}/autonity.service".format(folder), 'w') as out:
             out.write(content)

--- a/docker_e2e_test/client/client.py
+++ b/docker_e2e_test/client/client.py
@@ -139,7 +139,7 @@ class Client(object):
                    "[Service]\n" \
                    "Type=simple\n" \
                    "ExecStart={} --datadir {} --nodekey {} --syncmode 'full' --port {} " \
-                   "--rpcport {} --rpc --rpcaddr '0.0.0.0' --ws --wsport {} --rpccorsdomain '*' "\
+                   "--http.port {} --http --http.addr '0.0.0.0' --ws --wsport {} --rpccorsdomain '*' "\
                    "--rpcapi 'personal,debug,db,eth,net,web3,txpool,miner,tendermint,clique' --networkid 1991  " \
                    "--gasprice '0' --allow-insecure-unlock --graphql " \
                    "--unlock 0x{} --password {} " \

--- a/docker_e2e_test/clientDockerFile
+++ b/docker_e2e_test/clientDockerFile
@@ -14,6 +14,6 @@ RUN mkdir /root/.ssh
 RUN useradd -m -p '$6$MtwVl8yJ/PeTevqf$C.7ANQ7EzLLP9b6dXte9keVRYeUDDZ2i579yEIA4nPRpx8DMvxkRx3mZSYbZHCdzh8rmvq/PAvV9zTwp/i6o1/' -g sudo -G sudo tester
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-EXPOSE 22 6000 7000 8000 9000 30303
+EXPOSE 22 6000 7000 8000 30303
 CMD    ["/usr/sbin/sshd", "-D"]
 CMD    ["/lib/systemd/systemd"]

--- a/docker_e2e_test/e2etestengine.py
+++ b/docker_e2e_test/e2etestengine.py
@@ -52,8 +52,7 @@ if __name__ == '__main__':
             test_bed = conf.get_test_bed_conf()
             try:
                 for node in test_bed["targetNetwork"]["nodes"]:
-                    client = Client(host=node["name"], p2p_port=node["p2pPort"], rpc_port=node["rpcPort"],
-                                    ws_port=node["wsPort"], graphql_port=node["graphqlPort"],
+                    client = Client(host=node["name"], p2p_port=node["p2pPort"], rpc_port=node["rpcPort"], ws_port=node["wsPort"],
                                     net_interface=node["ethernetInterfaceID"], coin_base=node["coinBase"][2:],
                                     ssh_user=node["sshCredential"]["sshUser"], ssh_pass=node["sshCredential"]["sshPass"],
                                     ssh_key=node["sshCredential"]["sshKey"], sudo_pass=node["sshCredential"]["sudoPass"],

--- a/docker_e2e_test/etc/e2e_test_conf.yml
+++ b/docker_e2e_test/etc/e2e_test_conf.yml
@@ -17,7 +17,6 @@ test_bed_template:
         rpcPort: 6000 # must
         p2pPort: 30303
         wsPort: 7000
-        graphqlPort: 9000
         coinBase: "0xDB3B0a10faE93b6D3cA881C5F13D1D9313Ddae5A"
         k8sCredential:
           Token: "Get if from devop teammate if we use k8s API"

--- a/docker_e2e_test/planner/networkplanner.py
+++ b/docker_e2e_test/planner/networkplanner.py
@@ -73,7 +73,6 @@ class NetworkPlanner(object):
                 # sync template data to client instance.
                 client.p2p_port = node_template["p2pPort"]
                 client.rpc_port = node_template["rpcPort"]
-                client.graphql_port = node_template["graphqlPort"]
                 client.ws_port = node_template["wsPort"]
                 client.net_interface = node_template["ethernetInterfaceID"]
                 client.ssh_key = node_template["sshCredential"]["sshKey"]
@@ -89,7 +88,6 @@ class NetworkPlanner(object):
                 node["coinBase"] = "0x{}".format(client.coin_base)
                 node["p2pPort"] = client.p2p_port
                 node["rpcPort"] = client.rpc_port
-                node["graphqlPort"] = client.graphql_port
                 node["wsPort"] = client.ws_port
                 node["ethernetInterfaceID"] = client.net_interface
                 node["sshCredential"]["sshKey"] = client.ssh_key


### PR DESCRIPTION
e2e test framework configuration change to align with upstream's latest update.
--rpc to --http
--rpcaddr to --http.addr
--rpcport to --http.port
--graphql.port to be removed.  (graphql service is now depend on http service, share the same port, so its port flag is removed by upstream)