### PR TITLE
Fix double runs of github actions jobs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,13 @@
 name: Go
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    branches:
+      # Branches from forks have the form 'user:branch-name' so we only run
+      # this job on pull_request events for branches that look like fork
+      # branches. Without this we would end up running this job twice for non
+      # forked PRs, once for the push and then once for opening the PR.
+    - '**:**'
 jobs:
   bootstrap-checkout:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We updated our github actions workflow to run on pull requests in #709 because it was needed to be able to trigger the job on the PR coming from a forked repo. This had the undesirable effect of making the go job run twice for non forked PRs. There is no simple solution for this problem see - https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662.

This PR is an attempt to ensure we don't trigger jobs for non forked PRs. 

It looks like forked PRs take the form `user:branch-name` so this PR avoids triggering jobs for PRs except for branches that contain a colon.