### PR TITLE
Future proposal consensus fix

### DIFF
--- a/autonity/autonity.go
+++ b/autonity/autonity.go
@@ -77,7 +77,7 @@ func (ac *Contract) MeasureMetricsOfNetworkEconomic(header *types.Header, stateD
 	ABI := ac.contractABI
 
 	// pack the function which dump the data from contract.
-	input, err := ABI.Pack("dumpEconomicsMetricData")
+	input, err := ABI.Pack("dumpEconomicMetrics")
 	if err != nil {
 		log.Warn("Cannot pack the method: ", "err", err.Error())
 		return
@@ -95,7 +95,7 @@ func (ac *Contract) MeasureMetricsOfNetworkEconomic(header *types.Header, stateD
 	v := EconomicMetaData{make([]common.Address, 32), make([]uint8, 32), make([]*big.Int, 32),
 		make([]*big.Int, 32), new(big.Int), new(big.Int)}
 
-	if err := ABI.UnpackIntoInterface(&v, "dumpEconomicsMetricData", ret); err != nil {
+	if err := ABI.UnpackIntoInterface(&v, "dumpEconomicMetrics", ret); err != nil {
 		// can't work with aliased types
 		log.Warn("Could not unpack dumpNetworkEconomicsData returned value",
 			"err", err,

--- a/consensus/tendermint/core/propose.go
+++ b/consensus/tendermint/core/propose.go
@@ -114,6 +114,7 @@ func (c *core) handleProposal(ctx context.Context, msg *Message) error {
 					msg: msg,
 				})
 			})
+			return err
 		}
 		c.sendPrevote(ctx, true)
 		// do not to accept another proposal in current round

--- a/consensus/tendermint/core/propose.go
+++ b/consensus/tendermint/core/propose.go
@@ -125,16 +125,22 @@ func (c *core) handleProposal(ctx context.Context, msg *Message) error {
 		return err
 	}
 
-	// Here is about to accept the Proposal
+	// Set the proposal for the current round
+	c.curRoundMessages.SetProposal(&proposal, msg, true)
+
+	c.logProposalMessageEvent("MessageEvent(Proposal): Received", proposal, msg.Address.String(), c.address.String())
+
+	//l49: Check if we have a quorum of precommits for this proposal
+	curProposalHash := c.curRoundMessages.GetProposalHash()
+	if c.curRoundMessages.PrecommitsPower(curProposalHash) >= c.committeeSet().Quorum() {
+		c.commit(proposal.Round, c.curRoundMessages)
+		return nil
+	}
+
 	if c.step == propose {
 		if err := c.proposeTimeout.stopTimer(); err != nil {
 			return err
 		}
-
-		// Set the proposal for the current round
-		c.curRoundMessages.SetProposal(&proposal, msg, true)
-
-		c.logProposalMessageEvent("MessageEvent(Proposal): Received", proposal, msg.Address.String(), c.address.String())
 
 		vr := proposal.ValidRound
 		h := proposal.ProposalBlock.Hash()

--- a/consensus/tendermint/core/propose_test.go
+++ b/consensus/tendermint/core/propose_test.go
@@ -285,9 +285,7 @@ func TestHandleProposal(t *testing.T) {
 		logger := log.New("backend", "test", "id", 0)
 		proposalBlock := NewProposal(2, big.NewInt(1), 1, block)
 		proposal, err := Encode(proposalBlock)
-		if err != nil {
-			t.Fatalf("Expected <nil>, got %v", err)
-		}
+		assert.NoError(t, err)
 
 		msg := &Message{
 			Code:          msgProposal,
@@ -303,6 +301,7 @@ func TestHandleProposal(t *testing.T) {
 		}
 
 		valSet, err := newRoundRobinSet(testCommittee, testCommittee[0].Address)
+		assert.NoError(t, err)
 		backendMock := NewMockBackend(ctrl)
 		backendMock.EXPECT().VerifyProposal(gomock.Any()).Return(time.Second, consensus.ErrFutureBlock)
 		event := backlogEvent{
@@ -323,9 +322,7 @@ func TestHandleProposal(t *testing.T) {
 		}
 
 		err = c.handleProposal(context.Background(), msg)
-		if err == nil {
-			t.Fatalf("Expected non nil error, got %v", err)
-		}
+		assert.Error(t, err)
 		<-time.NewTimer(2 * time.Second).C
 	})
 


### PR DESCRIPTION
- Fix future proposal handling: A bug in the handling of future proposals was spotted in the DevNet. The engine was incorrectly moving to the prevote round and setting the proposal for the current round as nil which was leading the node to hang and not be able to commit even though it received a quorum of precommits for a valid proposal. 

- Add missing L49 handling: in the scenario in which we receive a proposal P when core is not at the propose step, the proposal is simply ignored but it could be that we already have a quorum of precommits, we must then commit if this occur.

- Renaming of dumpEconomicMetrics method which was forgotten.

Signed-off-by: yazzaoui <ya@clearmatics.com>