### PR TITLE
Race conditions fixes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -363,7 +363,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '9.x'
+          node-version: '10.x'
 
       - name: Cache code
         uses: actions/cache@v1

--- a/consensus/test/test_helpers_test.go
+++ b/consensus/test/test_helpers_test.go
@@ -193,6 +193,7 @@ func makeNodeConfig(t *testing.T, genesis *core.Genesis, nodekey *ecdsa.PrivateK
 		Genesis:         genesis,
 		NetworkId:       genesis.Config.ChainID.Uint64(),
 		SyncMode:        downloader.FullSync,
+		NoPruning:       true,
 		DatabaseCache:   256,
 		DatabaseHandles: 256,
 		TxPool:          core.DefaultTxPoolConfig,

--- a/consensus/test/test_helpers_test.go
+++ b/consensus/test/test_helpers_test.go
@@ -193,7 +193,6 @@ func makeNodeConfig(t *testing.T, genesis *core.Genesis, nodekey *ecdsa.PrivateK
 		Genesis:         genesis,
 		NetworkId:       genesis.Config.ChainID.Uint64(),
 		SyncMode:        downloader.FullSync,
-		NoPruning:       true,
 		DatabaseCache:   256,
 		DatabaseHandles: 256,
 		TxPool:          core.DefaultTxPoolConfig,

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -152,7 +152,7 @@ func (miner *Miner) Stop() {
 }
 
 func (miner *Miner) Close() {
-	close(miner.exitCh)
+	miner.exitCh <- struct{}{}
 }
 
 func (miner *Miner) Mining() bool {


### PR DESCRIPTION
- Go-leak when the miner closes. We enforce now that the miner has properly exited before shutting down the consensus engine during the closing flow of the ethereum backend.

Signed-off-by: yazzaoui <ya@clearmatics.com>