### PR TITLE
Change node version from 9.x to 10.x

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -363,7 +363,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '9.x'
+          node-version: '10.x'
 
       - name: Cache code
         uses: actions/cache@v1


### PR DESCRIPTION
This allows us to work with the latest version of truffle which uses
'for await of'.