### PR TITLE
Handle nodejs console repl exit event

### DIFF
--- a/nodejsconsole/console
+++ b/nodejsconsole/console
@@ -897,6 +897,9 @@ ws.addEventListener('message', event => {
 	// Setting context values makes them available in the default scope
 	// of the repl.
 	server.context.web3 = web3;
+	server.on('exit', () => {
+		process.exit();
+	});
 
 	// If the tendermint module is loaded then load the contract bindings
 	if (parsed.result.hasOwnProperty('tendermint')) {


### PR DESCRIPTION
Now we exit the node process when the repl is exited.

Fixes #728 