### PR TITLE
Fix for CVE-2020-28362

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Autonity in a stock Go builder container
-FROM golang:1.15-alpine as builder
+FROM golang:1.15.5-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers libc-dev git perl-utils
 


### PR DESCRIPTION
See - https://blog.ethereum.org/2020/11/12/geth_security_release

There was a CVE in go versions less than 1.15.5 that affected geth. The
fix is to build geth with a go version of 1.15.5 or greater.

Here we update the Dockerfile to ensure autonity is built with go
1.15.5.