### PR TITLE
Restore conformance tests at their latest passing version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -103,9 +103,47 @@ jobs:
           yml: codecov.yml
 
   tests-conformance:
+    needs: bootstrap-checkout
     runs-on: ubuntu-latest
     steps:
-      - run: echo "We don't run the conformance tests any more"
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Cache code
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-autonity-code
+        with:
+          path: /home/runner/work/autonity/autonity/
+          key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ github.sha }}
+
+      - uses: actions/checkout@v2
+        if: steps.cache-autonity-code.outputs.cache-hit != 'true'
+        with:
+          clean: 'false'
+
+      - name: Embed Autonity contract
+        if:  steps.cache-autonity-code.outputs.cache-hit != 'true'
+        run: make embed-autonity-contract
+
+      - name: Cache git modules
+        uses: actions/cache@v1
+        id: cache-git-modules
+        env:
+          cache-name: cache-git-modules
+        with:
+          path: /home/runner/work/autonity/autonity/tests/testdata
+          key: ${{ runner.os }}-aut-${{ env.cache-name }}-${{ hashFiles('**/.gitmodules') }}
+
+      - name: get conformance tests
+        if: steps.cache-git-modules.outputs.cache-hit != 'true'
+        run: git submodule update --init --recursive
+
+      - name: unit tests
+        run: go test -timeout 30m ./tests/...
 
   build:
     needs: bootstrap-checkout


### PR DESCRIPTION
Conformance tests have been failing since commit 7656dcc. That commit
(presumably accidentally) updated the `testdata` submodule to a later
revision.

The first change in conformance tests that breaks Autonity is coming
from ethereum/tests#676. Reset the `testdata` submodule to the latest
passing version until we figure out how to fix or work around the
failures that are caused by recent changes in the test repository.