### PR TITLE
Run go workflow on manual trigger and all PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,7 @@
 name: Go
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
 jobs:
   bootstrap-checkout:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,13 +1,7 @@
 name: Go
 on:
-  push:
-  pull_request:
-    branches:
-      # Branches from forks have the form 'user:branch-name' so we only run
-      # this job on pull_request events for branches that look like fork
-      # branches. Without this we would end up running this job twice for non
-      # forked PRs, once for the push and then once for opening the PR.
-    - '**:**'
+  workflow_dispatch:
+  pull_request_target:
 jobs:
   bootstrap-checkout:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change should ensure that we run the workflow on all pull requests including those from forks and also gives us the ability to trigger the go workflow manually.

It removes the push event which means we will no longer automatically run the go workflow every time we push. 