### PR TITLE
Fix slow-e2e-tests ensure we embed contract

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -196,6 +196,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
+        # Required for compilation since the test commands are not make
+        # targets that depend on embed-autonity-contract.
+      - run: make embed-autonity-contract
+
       - name: Go cache
         uses: actions/cache@v2
         with:
@@ -205,7 +209,7 @@ jobs:
           key: ${{ runner.os }}-gocache-${{ env.GO_VERSION }}${{ hashFiles('go.mod', 'go.sum') }}
 
       - name: slow-e2e-tests
-        run: go test ./consensus/test/... -v -blockperiod=1 -timeout=2h
+        run: go test ./consensus/test/... -v -blockperiod=1 -timeout=1h
 
   # docker-e2e-test runs the docker e2e test, it only runs on merges to the
   # develop branch because it takes hours to complete and so is not feasible to


### PR DESCRIPTION
In the slow-e2e-tests job that only runs on develop, I forgot to embed the autonity contract, this PR fixes that.

Also reduce timeout to 1h, since tests take ~40m to run.